### PR TITLE
Fix dev installation instructions in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Follow these steps to create a virtual environment and install this package:
     > This will install tools like `pre-commit` and `mypy`. To enable automatic checks before each commit using `pre-commit` hooks, run:
     > ```bash
     > pre-commit install
+    > ```
 
 ## Usage
 The example scripts [`lti_dd_mpc_example.py`](examples/lti_control/lti_dd_mpc_example.py) and [`nonlinear_dd_mpc_example.py`](examples/nonlinear_control/nonlinear_dd_mpc_example.py)demonstrate the setup, simulation, and data visualization of the Data-Driven MPC controllers applied to LTI and Nonlinear systems, respectively.

--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ Follow these steps to create a virtual environment and install this package:
     pip install -e .
     ```
 
-    > [!NOTE]
-    > If you plan to contribute to or develop the project, you can install optional development dependencies by running:
-    > ```bash
-    > pip install -e ".[dev]"
-    > ```
-    > This will install tools like `pre-commit` and `mypy`. To enable automatic checks before each commit using `pre-commit` hooks, run:
-    > ```bash
-    > pre-commit install
-    > ```
+> [!NOTE]
+> If you plan to contribute to or develop the project, you can install optional development dependencies by running:
+> ```bash
+> pip install -e ".[dev]"
+> ```
+> This will install tools like `pre-commit` and `mypy`. To enable automatic checks before each commit using `pre-commit` hooks, run:
+> ```bash
+> pre-commit install
+> ```
 
 ## Usage
 The example scripts [`lti_dd_mpc_example.py`](examples/lti_control/lti_dd_mpc_example.py) and [`nonlinear_dd_mpc_example.py`](examples/nonlinear_control/nonlinear_dd_mpc_example.py)demonstrate the setup, simulation, and data visualization of the Data-Driven MPC controllers applied to LTI and Nonlinear systems, respectively.


### PR DESCRIPTION
This PR ensures that the instructions for installing development dependencies in `README.md` are correctly rendered on GitHub.

### Key changes:
- Closed a code block in the development dependency installation note.
- Removed indentation from this note to ensure it's correctly rendered on GitHub.
