### PR TITLE
 Modernize type hints using built-in generic types and union operator

### DIFF
--- a/direct_data_driven_mpc/lti_data_driven_mpc_controller.py
+++ b/direct_data_driven_mpc/lti_data_driven_mpc_controller.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List, Optional
 
 import cvxpy as cp
 import numpy as np
@@ -51,17 +50,17 @@ class LTIDataDrivenMPCController:
         R (np.ndarray): The input weighting matrix for the MPC formulation.
         u_s (np.ndarray): The setpoint for control inputs.
         y_s (np.ndarray): The setpoint for system outputs.
-        eps_max (Optional[float]): The estimated upper bound of the system
+        eps_max (float | None): The estimated upper bound of the system
             measurement noise.
-        lamb_alpha (Optional[float]): The ridge regularization base weight for
+        lamb_alpha (float | None]): The ridge regularization base weight for
             `alpha`, scaled by `eps_max`.
-        lamb_sigma (Optional[float]): The ridge regularization weight for
+        lamb_sigma (float | None]): The ridge regularization weight for
             `sigma`.
-        U (Optional[np.ndarray]): An array of shape (`m`, 2) containing the
+        U (np.ndarray | None): An array of shape (`m`, 2) containing the
             bounds for the `m` predicted inputs. Each row specifies the
             `[min, max]` bounds for a single input. If `None`, no input bounds
             are applied.
-        c (Optional[float]): A constant used to define a Convex constraint for
+        c (float | None): A constant used to define a Convex constraint for
             the slack variable `sigma` in a Robust MPC formulation.
         slack_var_constraint_type (SlackVarConstraintTypes): The constraint
             type for the slack variable `sigma` in a Robust MPC formulation.
@@ -78,17 +77,17 @@ class LTIDataDrivenMPCController:
             input-output trajectory characterization of the system.
         ubar (cp.Variable): The predicted control input variable.
         ybar (cp.Variable): The predicted system output variable.
-        sigma (Optional[cp.Variable]): The slack variable to account for noisy
+        sigma (cp.Variable | None): The slack variable to account for noisy
             measurements in a Robust Data-Driven MPC.
-        dynamics_constraints (List[cp.Constraint]): The system dynamics
+        dynamics_constraints (list[cp.Constraint]): The system dynamics
             constraints for a Data-Driven MPC formulation.
-        internal_state_constraints (List[cp.Constraint]): The internal state
+        internal_state_constraints (list[cp.Constraint]): The internal state
             constraints for a Data-Driven MPC formulation.
-        terminal_constraints (List[cp.Constraint]): The terminal state
+        terminal_constraints (list[cp.Constraint]): The terminal state
             constraints for a Data-Driven MPC formulation.
-        slack_var_constraint (List[cp.Constraint]): The slack variable
+        slack_var_constraint (list[cp.Constraint]): The slack variable
             constraints for a Robust Data-Driven MPC formulation.
-        constraints (List[cp.Constraint]): The combined constraints for the
+        constraints (list[cp.Constraint]): The combined constraints for the
             Data-Driven MPC formulation.
         cost (cp.Expression): The cost function for the Data-Driven MPC
             formulation.
@@ -117,11 +116,11 @@ class LTIDataDrivenMPCController:
         R: np.ndarray,
         u_s: np.ndarray,
         y_s: np.ndarray,
-        eps_max: Optional[float] = None,
-        lamb_alpha: Optional[float] = None,
-        lamb_sigma: Optional[float] = None,
-        U: Optional[np.ndarray] = None,
-        c: Optional[float] = None,
+        eps_max: float | None = None,
+        lamb_alpha: float | None = None,
+        lamb_sigma: float | None = None,
+        U: np.ndarray | None = None,
+        c: float | None = None,
         slack_var_constraint_type: SlackVarConstraintType = (
             SlackVarConstraintType.CONVEX
         ),
@@ -152,17 +151,17 @@ class LTIDataDrivenMPCController:
                 formulation.
             u_s (np.ndarray): The setpoint for control inputs.
             y_s (np.ndarray): The setpoint for system outputs.
-            eps_max (Optional[float]): The estimated upper bound of the system
+            eps_max (float | None): The estimated upper bound of the system
                 measurement noise.
-            lamb_alpha (Optional[float]): The ridge regularization base weight
+            lamb_alpha (float | None): The ridge regularization base weight
                 for `alpha`. It is scaled by `eps_max`.
-            lamb_sigma (Optional[float]): The ridge regularization weight for
+            lamb_sigma (float | None): The ridge regularization weight for
                 `sigma`.
-            U (Optional[np.ndarray]): An array of shape (`m`, 2) containing
+            U (np.ndarray | None): An array of shape (`m`, 2) containing
                 the bounds for the `m` predicted inputs. Each row specifies
                 the `[min, max]` bounds for a single input. If `None`, no
                 input bounds are applied. Defaults to `None`.
-            c (Optional[float]): A constant used to define a Convex constraint
+            c (float | None): A constant used to define a Convex constraint
                 for the slack variable `sigma` in a Robust MPC formulation.
             slack_var_constraint_type (SlackVarConstraintTypes): The
                 constraint type for the slack variable `sigma` in a Robust MPC
@@ -593,7 +592,7 @@ class LTIDataDrivenMPCController:
             + self.slack_var_constraint
         )
 
-    def define_system_dynamic_constraints(self) -> List[cp.Constraint]:
+    def define_system_dynamic_constraints(self) -> list[cp.Constraint]:
         """
         Define the system dynamic constraints for the Data-Driven MPC
         formulation corresponding to the specified MPC controller type.
@@ -613,7 +612,7 @@ class LTIDataDrivenMPCController:
         - Robust MPC: Equation (6a).
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY system dynamic
+            list[cp.Constraint]: A list containing the CVXPY system dynamic
                 constraints for the Data-Driven MPC controller, corresponding
                 to the specified MPC controller type.
 
@@ -638,7 +637,7 @@ class LTIDataDrivenMPCController:
 
         return dynamics_constraints
 
-    def define_internal_state_constraints(self) -> List[cp.Constraint]:
+    def define_internal_state_constraints(self) -> list[cp.Constraint]:
         """
         Define the internal state constraints for the Data-Driven MPC
         formulation.
@@ -653,7 +652,7 @@ class LTIDataDrivenMPCController:
         and (6b) (Robust) from the Nominal and Robust MPC formulations in [1].
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY internal state
+            list[cp.Constraint]: A list containing the CVXPY internal state
                 constraints for the Data-Driven MPC controller.
 
         Note:
@@ -676,7 +675,7 @@ class LTIDataDrivenMPCController:
 
     def define_terminal_state_constraints(
         self, u_s: np.ndarray, y_s: np.ndarray
-    ) -> List[cp.Constraint]:
+    ) -> list[cp.Constraint]:
         """
         Define the terminal state constraints for the Data-Driven MPC
         formulation.
@@ -690,7 +689,7 @@ class LTIDataDrivenMPCController:
         (6c) (Robust) from the Nominal and Robust MPC formulations in [1].
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY terminal state
+            list[cp.Constraint]: A list containing the CVXPY terminal state
                 constraints for the Data-Driven MPC controller.
 
         References:
@@ -716,14 +715,14 @@ class LTIDataDrivenMPCController:
 
         return terminal_constraints
 
-    def define_input_constraints(self) -> List[cp.Constraint]:
+    def define_input_constraints(self) -> list[cp.Constraint]:
         """
         Define the input constraints for the Data-Driven MPC formulation.
 
         These constraints are defined according to Equation (6c) of [1].
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY input constraints
+            list[cp.Constraint]: A list containing the CVXPY input constraints
                 for the Data-Driven MPC controller.
         """
         # Define input constraints
@@ -735,7 +734,7 @@ class LTIDataDrivenMPCController:
 
         return input_constraints
 
-    def define_slack_variable_constraint(self) -> List[cp.Constraint]:
+    def define_slack_variable_constraint(self) -> list[cp.Constraint]:
         """
         Define the slack variable constraint for a Robust Data-Driven MPC
         formulation based on the specified slack variable constraint type.
@@ -754,7 +753,7 @@ class LTIDataDrivenMPCController:
             (Remark 3).
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY slack variable
+            list[cp.Constraint]: A list containing the CVXPY slack variable
                 constraint for the Robust Data-Driven MPC controller,
                 corresponding to the specified slack variable constraint type.
                 The list is empty if the `NONE` constraint type is selected.

--- a/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
+++ b/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List, Optional
 
 import cvxpy as cp
 import numpy as np
@@ -81,7 +80,7 @@ class NonlinearDataDrivenMPCController:
         u_s (cp.Variable): The predicted equilibrium input variable.
         y_s (cp.Variable): The predicted equilibrium output variable.
         sigma (cp.Variable): The optimization variable for `sigma`.
-        sigma_ubar (Optional[Vstack]): A CVXPY `Vstack` object that stacks the
+        sigma_ubar (Vstack | None): A CVXPY `Vstack` object that stacks the
             `sigma` values corresponding to the input. Defined only if the
             controller uses an extended output representation.
         u_s_tiled (Vstack): A CVXPY `Vstack` object that stacks the predicted
@@ -89,26 +88,26 @@ class NonlinearDataDrivenMPCController:
         y_s_tiled (Vstack): A CVXPY `Vstack` object that stacks the predicted
             output setpoint variables for use in the cost function
             formulation.
-        alpha_s (Optional[cp.Variable]): The optimization variable for
-            `alpha_s`. Defined only if `alpha` is regularized with respect to
-            an approximation of `alpha_Lin^sr(D_t)`.
-        sigma_s (Optional[cp.Variable]): The optimization variable for
-            `sigma_s`. Defined only if `alpha` is regularized with respect to
-            an approximation of `alpha_Lin^sr(D_t)`.
-        sigma_s_ubar (Optional[Vstack]): A CVXPY `Vstack` object that stacks
-            the `sigma_s` values corresponding to the input. Defined only if
-            the controller uses an extended output representation and if
-            `alpha` is regularized with respect to an approximation of
+        alpha_s (cp.Variable | None): The optimization variable for `alpha_s`.
+            Defined only if `alpha` is regularized with respect to an
+            approximation of `alpha_Lin^sr(D_t)`.
+        sigma_s (cp.Variable | None): The optimization variable for `sigma_s`.
+            Defined only if `alpha` is regularized with respect to an
+            approximation of `alpha_Lin^sr(D_t)`.
+        sigma_s_ubar (Vstack | None): A CVXPY `Vstack` object that stacks the
+            `sigma_s` values corresponding to the input. Defined only if the
+            controller uses an extended output representation and if `alpha` is
+            regularized with respect to an approximation of
             `alpha_Lin^sr(D_t)`.
-        dynamics_constraint (List[cp.Constraint]): The system dynamics
+        dynamics_constraint (list[cp.Constraint]): The system dynamics
             constraints for a Data-Driven MPC formulation.
-        internal_state_constraint (List[cp.Constraint]): The internal state
+        internal_state_constraint (list[cp.Constraint]): The internal state
             constraints for a Data-Driven MPC formulation.
-        terminal_constraint (List[cp.Constraint]): The terminal state
+        terminal_constraint (list[cp.Constraint]): The terminal state
             constraints for a Data-Driven MPC formulation.
-        input_constraints (List[cp.Constraint]): The input constraints for a
+        input_constraints (list[cp.Constraint]): The input constraints for a
             Data-Driven MPC formulation.
-        constraints (List[cp.Constraint]): The combined constraints for the
+        constraints (list[cp.Constraint]): The combined constraints for the
             Data-Driven MPC formulation.
         cost (cp.Expression): The cost function for the Data-Driven MPC
             formulation.
@@ -116,12 +115,12 @@ class NonlinearDataDrivenMPCController:
             Data-Driven MPC.
         optimal_u (np.ndarray): The optimal control input derived from the
             Data-Driven MPC solution.
-        optimal_du (Optional[np.ndarray]): The optimal control input
-            increments derived from the Data-Driven MPC solution. Defined only
-            for controllers with an extended output representation and input
+        optimal_du (np.ndarray | None): The optimal control input increments
+            derived from the Data-Driven MPC solution. Defined only for
+            controllers with an extended output representation and input
             increments.
-        prev_alpha_val (Optional[np.ndarray]): The previous value of `alpha`
-            used for when `alpha` is regularized with respect to the previous
+        prev_alpha_val (np.ndarray | None): The previous value of `alpha` used
+            for when `alpha` is regularized with respect to the previous
             optimal `alpha` value. Defined only if `alpha` is regularized with
             respect to its previous optimal alpha value.
         ones_NLn (np.ndarray): A vector of ones of shape (1, N - L - n).
@@ -160,10 +159,10 @@ class NonlinearDataDrivenMPCController:
         U: np.ndarray,
         Us: np.ndarray,
         alpha_reg_type: AlphaRegType = AlphaRegType.ZERO,
-        lamb_alpha_s: Optional[float] = None,
-        lamb_sigma_s: Optional[float] = None,
+        lamb_alpha_s: float | None = None,
+        lamb_sigma_s: float | None = None,
         ext_out_incr_in: bool = False,
-        update_cost_threshold: Optional[float] = None,
+        update_cost_threshold: float | None = None,
         n_mpc_step: int = 1,
     ):
         """
@@ -215,7 +214,7 @@ class NonlinearDataDrivenMPCController:
                 (u[k] = u[k-1] + du[k-1]). If `False`, the controller operates
                 as a standard controller with direct control inputs and
                 without system state extensions. Defaults to `False`.
-            update_cost_threshold (Optional[float]): The tracking cost value
+            update_cost_threshold (float | None): The tracking cost value
                 threshold. Online input-output data updates are disabled when
                 the tracking cost value is less than this value. If `None`,
                 input-output data is always updated online. Defaults to
@@ -844,7 +843,7 @@ class NonlinearDataDrivenMPCController:
             + self.input_constraints
         )
 
-    def define_system_dynamic_constraints(self) -> List[cp.Constraint]:
+    def define_system_dynamic_constraints(self) -> list[cp.Constraint]:
         """
         Define the system dynamic constraints for the Data-Driven MPC
         formulation.
@@ -857,7 +856,7 @@ class NonlinearDataDrivenMPCController:
         These constraints are defined according to Equation (22b) of [2].
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY system dynamic
+            list[cp.Constraint]: A list containing the CVXPY system dynamic
                 constraints for the Data-Driven MPC controller, corresponding
                 to the specified MPC controller type.
 
@@ -880,7 +879,7 @@ class NonlinearDataDrivenMPCController:
 
         return dynamics_constraints
 
-    def define_internal_state_constraints(self) -> List[cp.Constraint]:
+    def define_internal_state_constraints(self) -> list[cp.Constraint]:
         """
         Define the internal state constraints for the Data-Driven MPC
         formulation.
@@ -894,7 +893,7 @@ class NonlinearDataDrivenMPCController:
         These constraints are defined according to Equation (22c) of [2].
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY internal state
+            list[cp.Constraint]: A list containing the CVXPY internal state
                 constraints for the Data-Driven MPC controller.
 
         Note:
@@ -917,7 +916,7 @@ class NonlinearDataDrivenMPCController:
 
         return internal_state_constraints
 
-    def define_terminal_state_constraints(self) -> List[cp.Constraint]:
+    def define_terminal_state_constraints(self) -> list[cp.Constraint]:
         """
         Define the terminal state constraints for the Data-Driven MPC
         formulation.
@@ -931,7 +930,7 @@ class NonlinearDataDrivenMPCController:
         These constraints are defined according to Equation (22d) of [2].
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY terminal state
+            list[cp.Constraint]: A list containing the CVXPY terminal state
                 constraints for the Data-Driven MPC controller.
 
         References:
@@ -951,14 +950,14 @@ class NonlinearDataDrivenMPCController:
 
         return terminal_constraints
 
-    def define_input_constraints(self) -> List[cp.Constraint]:
+    def define_input_constraints(self) -> list[cp.Constraint]:
         """
         Define the input constraints for the Data-Driven MPC formulation.
 
         These constraints are defined according to Equation (22e) of [2].
 
         Returns:
-            List[cp.Constraint]: A list containing the CVXPY input constraints
+            list[cp.Constraint]: A list containing the CVXPY input constraints
                 for the Data-Driven MPC controller.
         """
         # Define input constraints
@@ -1193,7 +1192,7 @@ class NonlinearDataDrivenMPCController:
         # mypy [assignment] is ignored since `alpha.value` could only be `None`
         # if `alpha` were a sparse matrix, which is not the case in our system
 
-    def get_du_value_at_step(self, n_step: int = 0) -> Optional[np.ndarray]:
+    def get_du_value_at_step(self, n_step: int = 0) -> np.ndarray | None:
         """
         Get the optimal control input increment (`du`) from the MPC solution
         corresponding to a specified time step in the prediction horizon
@@ -1204,7 +1203,7 @@ class NonlinearDataDrivenMPCController:
                 retrieve. It must be within the range [0, L].
 
         Returns:
-            Optional[np.ndarray]: An array containing the optimal control
+            np.ndarray | None: An array containing the optimal control
                 input increment for the specified prediction time step if the
                 controller uses an extended output representation and input
                 increments. Otherwise, returns `None`.
@@ -1222,7 +1221,7 @@ class NonlinearDataDrivenMPCController:
         self,
         u_current: np.ndarray,
         y_current: np.ndarray,
-        du_current: Optional[np.ndarray] = None,
+        du_current: np.ndarray | None = None,
     ) -> None:
         """
         Store an input-output measurement pair for the current time step in

--- a/direct_data_driven_mpc/utilities/controller/controller_params.py
+++ b/direct_data_driven_mpc/utilities/controller/controller_params.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TypedDict, Union
+from typing import TypedDict
 
 import numpy as np
 
@@ -51,7 +51,7 @@ class LTIDataDrivenMPCParamsDictType(TypedDict, total=False):
     lamb_sigma: float  # Regularization parameter for sigma
     c: float  # Convex slack variable constraint constant
 
-    U: Optional[np.ndarray]  # Bounds for the predicted input
+    U: np.ndarray | None  # Bounds for the predicted input
     u_range: np.ndarray  # Range of the persistently exciting input u
 
     # Slack variable constraint type
@@ -83,8 +83,8 @@ class NonlinearDataDrivenMPCParamsDictType(TypedDict, total=False):
 
     alpha_reg_type: AlphaRegType  # Alpha regularization type
 
-    lamb_alpha_s: Optional[float]  #  Regularization parameter for alpha_s
-    lamb_sigma_s: Optional[float]  #  Regularization parameter for sigma_s
+    lamb_alpha_s: float | None  #  Regularization parameter for alpha_s
+    lamb_sigma_s: float | None  #  Regularization parameter for sigma_s
 
     y_r: np.ndarray  # System output setpoint
 
@@ -92,7 +92,7 @@ class NonlinearDataDrivenMPCParamsDictType(TypedDict, total=False):
     # output representation and input increments, or operates as a standard
     # controller with direct control inputs without system state extensions
 
-    update_cost_threshold: Optional[float]  # Tracking cost value threshold
+    update_cost_threshold: float | None  # Tracking cost value threshold
 
     n_mpc_step: int  # Number of consecutive applications of the optimal input
 
@@ -501,7 +501,7 @@ def get_nonlinear_data_driven_mpc_controller_params(
 
 
 def construct_weighting_matrix(
-    weights_param: Union[float, List[float]],
+    weights_param: float | list[float],
     n_vars: int,
     horizon: int,
     matrix_label: str = "Weighting",
@@ -511,7 +511,7 @@ def construct_weighting_matrix(
     of weights.
 
     Args:
-        weights_param (Union[float, List[float]]): The weights for the matrix.
+        weights_param (float | list[float]): The weights for the matrix.
             - If scalar, applies the same weight to all variables.
             - If list, assigns specific weights to each variable. Must have
               `n_vars` elements.
@@ -556,15 +556,15 @@ def construct_weighting_matrix(
 
 
 def get_weights_list_from_param(
-    weights_param: Union[float, List[float]],
+    weights_param: float | list[float],
     size: int,
     matrix_label: str = "Weighting",
-) -> List[float]:
+) -> list[float]:
     """
     Construct a list of weights from a matrix weights parameter.
 
     Args:
-        weights_param (Union[float, List[float]]): A weighting parameter.
+        weights_param (float | list[float]): A weighting parameter.
             - If scalar, applies the same weight to all variables.
             - If list, must have `size` elements.
         size (int): The expected number of elements of the resulting list.
@@ -572,7 +572,7 @@ def get_weights_list_from_param(
             "Weighting".
 
     Returns:
-        List[float]: A list of weights of length `size`.
+        list[float]: A list of weights of length `size`.
 
     Raises:
         ValueError: If `weights_param` is not a valid scalar or list with the

--- a/direct_data_driven_mpc/utilities/controller/data_driven_mpc_sim.py
+++ b/direct_data_driven_mpc/utilities/controller/data_driven_mpc_sim.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Tuple
+from typing import Callable
 
 import numpy as np
 from numpy.random import Generator
@@ -22,7 +22,7 @@ def simulate_lti_data_driven_mpc_control_loop(
     n_steps: int,
     np_random: Generator,
     verbose: int,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Simulate a Data-Driven MPC control loop applied to a Linear Time-Invariant
     (LTI) system and return the resulting input-output data sequences.
@@ -44,7 +44,7 @@ def simulate_lti_data_driven_mpc_control_loop(
             2 = detailed output.
 
     Returns:
-        Tuple[np.ndarray, np.ndarray]: A tuple containing two arrays:
+        tuple[np.ndarray, np.ndarray]: A tuple containing two arrays:
             - An array of shape `(n_steps, m)` representing the optimal control
                 inputs applied to the system, where `m` is the number of
                 control inputs.
@@ -161,12 +161,11 @@ def simulate_nonlinear_data_driven_mpc_control_loop(
     n_steps: int,
     np_random: Generator,
     verbose: int,
-    callback: Optional[
-        Callable[
-            [int, NonlinearSystem, np.ndarray, np.ndarray, np.ndarray], None
-        ]
-    ] = None,
-) -> Tuple[np.ndarray, np.ndarray]:
+    callback: Callable[
+        [int, NonlinearSystem, np.ndarray, np.ndarray, np.ndarray], None
+    ]
+    | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Simulate a Data-Driven MPC control loop applied to a Nonlinear system and
     return the resulting input-output data sequences.
@@ -186,13 +185,13 @@ def simulate_nonlinear_data_driven_mpc_control_loop(
             random noise for the system's output.
         verbose (int): The verbosity level: 0 = no output, 1 = minimal output,
             2 = detailed output.
-        callback (Optional[Callable]): A function executed after each control
+        callback (Callable | None): A function executed after each control
             step. It should follow the signature `(step: int, system_model:
             NonlinearSystem, u_sys_k: np.ndarray, y_sys_k: np.ndarray, y_r:
             np.ndarray)`.
 
     Returns:
-        Tuple[np.ndarray, np.ndarray]: A tuple containing two arrays:
+        tuple[np.ndarray, np.ndarray]: A tuple containing two arrays:
             - An array of shape `(n_steps, m)` representing the optimal control
                 inputs applied to the system, where `m` is the number of
                 control inputs.
@@ -326,9 +325,9 @@ def print_mpc_step_info(
     mpc_cost_val: float,
     y_sys_k: np.ndarray,
     y_s: np.ndarray,
-    u_sys_k: Optional[np.ndarray] = None,
-    u_s: Optional[np.ndarray] = None,
-    progress_bar: Optional[tqdm] = None,
+    u_sys_k: np.ndarray | None = None,
+    u_s: np.ndarray | None = None,
+    progress_bar: tqdm | None = None,
 ) -> None:
     """
     Print MPC step information based on the verbosity level.
@@ -340,14 +339,14 @@ def print_mpc_step_info(
                 errors.
         step (int): Current time step.
         mpc_cost_val (float): The current MPC cost value.
-        u_s (Optional[np.ndarray]): The input setpoint array. If `None`, input
+        u_s (np.ndarray | None): The input setpoint array. If `None`, input
             errors will not be printed. Defaults to `None`.
-        u_sys_k (Optional[np.ndarray]): The input vector for the current time
+        u_sys_k (np.ndarray | None): The input vector for the current time
             step. If `None`, input errors will not be printed. Defaults to
             `None`.
         y_s (np.ndarray): The output setpoint array.
         y_sys_k (np.ndarray): The output vector for the current time step.
-        progress_bar (Optional[tqdm]): A progress bar displaying simulation
+        progress_bar (tqdm | None): A progress bar displaying simulation
             progress information.
     """
     if verbose == 1 and progress_bar is not None:

--- a/direct_data_driven_mpc/utilities/controller/initial_data_generation.py
+++ b/direct_data_driven_mpc/utilities/controller/initial_data_generation.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Union
-
 import numpy as np
 from numpy.random import Generator
 
@@ -88,10 +86,10 @@ def randomize_initial_system_state(
 
 
 def generate_initial_input_output_data(
-    system_model: Union[LTIModel, NonlinearSystem],
+    system_model: LTIModel | NonlinearSystem,
     controller_config: DataDrivenMPCParamsType,
     np_random: Generator,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Generate input-output trajectory data from a system using Data-Driven MPC
     controller parameters.
@@ -104,9 +102,9 @@ def generate_initial_input_output_data(
     for system characterization in a Data-Driven MPC formulation.
 
     Args:
-        system_model (Union[LTIModel, NonlinearSystem]): An instance of
-            `LTIModel` representing a Linear Time-Invariant (LTI) system or
-            `NonlinearSystem` representing a Nonlinear system.
+        system_model (LTIModel | NonlinearSystem): An instance of `LTIModel`,
+            representing a Linear Time-Invariant (LTI) system, or
+            `NonlinearSystem`, representing a Nonlinear system.
         controller_config (DataDrivenMPCParamsType): A dictionary containing
             parameters for a Data-Driven MPC controller designed for Linear
             Time-Invariant (LTI) or Nonlinear systems. Includes the initial
@@ -117,7 +115,7 @@ def generate_initial_input_output_data(
             output.
 
     Returns:
-        Tuple[np.ndarray, np.ndarray]: A tuple containing two arrays: a
+        tuple[np.ndarray, np.ndarray]: A tuple containing two arrays: a
             persistently exciting input (`u_d`) and the system's output
             response (`y_d`). The input array has shape `(N, m)` and the
             output array has shape `(N, p)`, where `N` is the trajectory
@@ -157,7 +155,7 @@ def simulate_n_input_output_measurements(
     system_model: LTIModel,
     controller_config: LTIDataDrivenMPCParamsDictType,
     np_random: Generator,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Simulate a control input setpoint applied to a system over `n` (the
     estimated system order) time steps and return the resulting input-output
@@ -187,7 +185,7 @@ def simulate_n_input_output_measurements(
             random noise for the system's output.
 
     Returns:
-        Tuple[np.ndarray, np.ndarray]: A tuple containing two arrays:
+        tuple[np.ndarray, np.ndarray]: A tuple containing two arrays:
             - An array of shape `(n, m)` representing the constant input
                 setpoint applied to the system over `n` time steps, where `n`
                 is the system order and `m` is the number of control inputs.

--- a/direct_data_driven_mpc/utilities/data_visualization.py
+++ b/direct_data_driven_mpc/utilities/data_visualization.py
@@ -1,6 +1,6 @@
 import math
 import os
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -31,7 +31,7 @@ class HandlerInitMeasurementRect(HandlerPatch):
         height: float,
         fontsize: float,
         trans: Transform,
-    ) -> List[Union[Rectangle, Line2D]]:
+    ) -> list[Rectangle | Line2D]:
         # Make sure orig_handle is a Rectangle
         assert isinstance(orig_handle, Rectangle)
 
@@ -72,31 +72,31 @@ def plot_input_output(
     u_k: np.ndarray,
     y_k: np.ndarray,
     y_s: np.ndarray,
-    u_s: Optional[np.ndarray] = None,
-    u_bounds_list: Optional[List[Tuple[float, float]]] = None,
-    y_bounds_list: Optional[List[Tuple[float, float]]] = None,
+    u_s: np.ndarray | None = None,
+    u_bounds_list: list[tuple[float, float]] | None = None,
+    y_bounds_list: list[tuple[float, float]] | None = None,
     inputs_line_params: dict[str, Any] | None = None,
     outputs_line_params: dict[str, Any] | None = None,
     setpoints_line_params: dict[str, Any] | None = None,
     bounds_line_params: dict[str, Any] | None = None,
     u_setpoint_var_symbol: str = "u^s",
     y_setpoint_var_symbol: str = "y^s",
-    initial_steps: Optional[int] = None,
+    initial_steps: int | None = None,
     initial_excitation_text: str = "Init. Excitation",
     initial_measurement_text: str = "Init. Measurement",
     control_text: str = "Data-Driven MPC",
     display_initial_text: bool = True,
     display_control_text: bool = True,
-    figsize: Tuple[float, float] = (12.0, 8.0),
+    figsize: tuple[float, float] = (12.0, 8.0),
     dpi: int = 300,
-    u_ylimits_list: Optional[List[Tuple[float, float]]] = None,
-    y_ylimits_list: Optional[List[Tuple[float, float]]] = None,
+    u_ylimits_list: list[tuple[float, float]] | None = None,
+    y_ylimits_list: list[tuple[float, float]] | None = None,
     fontsize: int = 12,
     legend_params: dict[str, Any] | None = None,
     data_label: str = "",
-    axs_u: Optional[List[Axes]] = None,
-    axs_y: Optional[List[Axes]] = None,
-    title: Optional[str] = None,
+    axs_u: list[Axes] | None = None,
+    axs_y: list[Axes] | None = None,
+    title: str | None = None,
 ) -> None:
     """
     Plot input-output data with setpoints in a Matplotlib figure.
@@ -129,18 +129,18 @@ def plot_input_output(
         y_k (np.ndarray): An array containing system output data of shape (T,
             p), where `p` is the number of outputs and `T` is the number of
             time steps.
-        u_s (Optional[np.ndarray]): An array of shape (m, 1) containing `m`
-            input setpoint values. If `None`, input setpoint lines will not
-            be plotted. Defaults to `None`.
+        u_s (np.ndarray | None): An array of shape (m, 1) containing `m` input
+            setpoint values. If `None`, input setpoint lines will not be
+            plotted. Defaults to `None`.
         y_s (np.ndarray): An array of shape (p, 1) containing `p` output
             setpoint values.
-        u_bounds_list (Optional[List[Tuple[float, float]]]): A list of tuples
+        u_bounds_list (list[tuple[float, float]] | None): A list of tuples
             (lower_bound, upper_bound) specifying bounds for each input data
             sequence. If provided, horizontal lines representing these bounds
             will be plotted in each subplot. If `None`, no horizontal lines
             will be plotted. The number of tuples must match the number of
             input data sequences. Defaults to `None`.
-        y_bounds_list (Optional[List[Tuple[float, float]]]): A list of tuples
+        y_bounds_list (list[tuple[float, float]] | None): A list of tuples
             (lower_bound, upper_bound) specifying bounds for each output data
             sequence. If provided, horizontal lines representing these bounds
             will be plotted in each subplot. If `None`, no horizontal lines
@@ -166,7 +166,7 @@ def plot_input_output(
             input setpoint data series (e.g., "u^s").
         y_setpoint_var_symbol (str): The variable symbol used to label the
             output setpoint data series (e.g., "y^s").
-        initial_steps (Optional[int]): The number of initial time steps during
+        initial_steps (int | None): The number of initial time steps during
             which input-output measurements were taken for the data-driven
             characterization of the system. This highlights the initial
             measurement period in the plot. If `None`, no special highlighting
@@ -183,14 +183,14 @@ def plot_input_output(
             label on the plot. Default is True.
         display_control_text (bool): Whether to display the `control_text`
             label on the plot. Default is True.
-        figsize (Tuple[float, float]): The (width, height) dimensions of the
+        figsize (tuple[float, float]): The (width, height) dimensions of the
             created Matplotlib figure.
         dpi (int): The DPI resolution of the figure.
-        u_ylimits_list (Optional[List[Tuple[float, float]]]): A list of tuples
+        u_ylimits_list (list[tuple[float, float]] | None): A list of tuples
             (lower_limit, upper_limit) specifying the Y-axis limits for each
             input subplot. If `None`, the Y-axis limits will be determined
             automatically. Defaults to `None`.
-        y_ylimits_list (Optional[List[Tuple[float, float]]]): A list of tuples
+        y_ylimits_list (list[tuple[float, float]] | None): A list of tuples
             (lower_limit, upper_limit) specifying the Y-axis limits for each
             output subplot. If `None`, the Y-axis limits will be determined
             automatically. Defaults to `None`.
@@ -200,14 +200,14 @@ def plot_input_output(
             loc, handlelength). If not provided, Matplotlib's default legend
             properties will be used.
         data_label (str): The label for the current data sequences.
-        axs_u (Optional[List[Axes]]): List of external axes for input plots.
+        axs_u (list[Axes] | None): A list of external axes for input plots.
             Defaults to `None`.
-        axs_y (Optional[List[Axes]]): List of external axes for output plots.
+        axs_y (list[Axes] | None): A list of external axes for output plots.
             Defaults to `None`.
-        title (Optional[str]): The title for the created plot figure. Set
-            only if the figure is created internally (i.e., `axs_u` and
-            `axs_y` are not provided). If `None`, no title will be displayed.
-            Defaults to `None`.
+        title (str | None): The title for the created plot figure. Set only if
+            the figure is created internally (i.e., `axs_u` and `axs_y` are not
+            provided). If `None`, no title will be displayed. Defaults to
+            `None`.
 
     Raises:
         ValueError: If any array dimensions mismatch expected shapes, or if
@@ -373,7 +373,7 @@ def plot_input_output(
 def plot_data(
     axis: Axes,
     data: np.ndarray,
-    setpoint: Optional[np.ndarray],
+    setpoint: np.ndarray | None,
     index: int,
     data_line_params: dict[str, Any],
     setpoint_line_params: dict[str, Any],
@@ -389,9 +389,9 @@ def plot_data(
     fontsize: int,
     legend_params: dict[str, Any],
     fig: Figure | SubFigure,
-    bounds: Optional[Tuple[float, float]] = None,
-    initial_steps: Optional[int] = None,
-    plot_ylimits: Optional[Tuple[float, float]] = None,
+    bounds: tuple[float, float] | None = None,
+    initial_steps: int | None = None,
+    plot_ylimits: tuple[float, float] | None = None,
 ) -> None:
     """
     Plot a data series with setpoints in a specified axis. Optionally,
@@ -406,7 +406,7 @@ def plot_data(
     Args:
         axis (Axes): The Matplotlib axis object to plot on.
         data (np.ndarray): An array containing data to be plotted.
-        setpoint (Optional[float]): The setpoint value for the data. If
+        setpoint (float | None): The setpoint value for the data. If
             `None`, the setpoint line will not be plotted.
         index (int): The index of the data used for labeling purposes (e.g.,
             "u_1", "u_2"). If set to -1, subscripts will not be added to
@@ -441,15 +441,15 @@ def plot_data(
             handlelength).
         fig (Figure | SubFigure): The Matplotlib figure or subfigure that
             contains the axis.
-        bounds (Optional[Tuple[float, float]]): A tuple (lower_bound,
+        bounds (tuple[float, float] | None): A tuple (lower_bound,
             upper_bound) specifying the bounds of the data to be plotted. If
             provided, horizontal lines representing these bounds will be
             plotted. Defaults to `None`.
-        initial_steps (Optional[int]): The number of initial time steps during
+        initial_steps (int | None): The number of initial time steps during
             which input-output measurements were taken for the data-driven
             characterization of the system. This highlights the initial
             measurement period in the plot. Defaults to `None`.
-        plot_ylimits (Optional[Tuple[float, float]]): A tuple (lower_limit,
+        plot_ylimits (tuple[float, float] | None): A tuple (lower_limit,
             upper_limit) specifying the Y-axis limits for the plot. If `None`,
             the Y-axis limits will be determined automatically. Defaults to
             `None`.
@@ -572,30 +572,30 @@ def plot_input_output_animation(
     u_k: np.ndarray,
     y_k: np.ndarray,
     y_s: np.ndarray,
-    u_s: Optional[np.ndarray] = None,
-    u_bounds_list: Optional[List[Tuple[float, float]]] = None,
-    y_bounds_list: Optional[List[Tuple[float, float]]] = None,
+    u_s: np.ndarray | None = None,
+    u_bounds_list: list[tuple[float, float]] | None = None,
+    y_bounds_list: list[tuple[float, float]] | None = None,
     inputs_line_params: dict[str, Any] | None = None,
     outputs_line_params: dict[str, Any] | None = None,
     setpoints_line_params: dict[str, Any] | None = None,
     bounds_line_params: dict[str, Any] | None = None,
     u_setpoint_var_symbol: str = "u^s",
     y_setpoint_var_symbol: str = "y^s",
-    initial_steps: Optional[int] = None,
-    initial_steps_label: Optional[str] = None,
+    initial_steps: int | None = None,
+    initial_steps_label: str | None = None,
     continuous_updates: bool = False,
     initial_excitation_text: str = "Init. Excitation",
     initial_measurement_text: str = "Init. Measurement",
     control_text: str = "Data-Driven MPC",
     display_initial_text: bool = True,
     display_control_text: bool = True,
-    figsize: Tuple[float, float] = (12.0, 8.0),
+    figsize: tuple[float, float] = (12.0, 8.0),
     dpi: int = 300,
     interval: float = 20.0,
     points_per_frame: int = 1,
     fontsize: int = 12,
     legend_params: dict[str, Any] | None = None,
-    title: Optional[str] = None,
+    title: str | None = None,
 ) -> FuncAnimation:
     """
     Create a Matplotlib animation showing the progression of input-output data
@@ -629,18 +629,18 @@ def plot_input_output_animation(
         y_k (np.ndarray): An array containing system output data of shape (T,
             p), where `p` is the number of outputs and `T` is the number of
             time steps.
-        u_s (Optional[np.ndarray]): An array of shape (m, 1) containing `m`
-            input setpoint values. If `None`, input setpoint lines will not
-            be plotted. Defaults to `None`.
+        u_s (np.ndarray | None): An array of shape (m, 1) containing `m` input
+            setpoint values. If `None`, input setpoint lines will not be
+            plotted. Defaults to `None`.
         y_s (np.ndarray): An array of shape (p, 1) containing `p` output
             setpoint values.
-        u_bounds_list (Optional[List[Tuple[float, float]]]): A list of tuples
+        u_bounds_list (list[tuple[float, float]] | None): A list of tuples
             (lower_bound, upper_bound) specifying bounds for each input data
             sequence. If provided, horizontal lines representing these bounds
             will be plotted in each subplot. If `None`, no horizontal lines
             will be plotted. The number of tuples must match the number of
             input data sequences. Defaults to `None`.
-        y_bounds_list (Optional[List[Tuple[float, float]]]): A list of tuples
+        y_bounds_list (list[tuple[float, float]] | None): A list of tuples
             (lower_bound, upper_bound) specifying bounds for each output data
             sequence. If provided, horizontal lines representing these bounds
             will be plotted in each subplot. If `None`, no horizontal lines
@@ -666,12 +666,12 @@ def plot_input_output_animation(
             input setpoint data series (e.g., "u^s").
         y_setpoint_var_symbol (str): The variable symbol used to label the
             output setpoint data series (e.g., "y^s").
-        initial_steps (Optional[int]): The number of initial time steps during
+        initial_steps (int | None): The number of initial time steps during
             which input-output measurements were taken for the data-driven
             characterization of the system. This highlights the initial
             measurement period in the plot. If `None`, no special highlighting
             will be applied. Defaults to `None`.
-        initial_steps_label (Optional[str]): Label text to use for the legend
+        initial_steps_label (str | None): Label text to use for the legend
             entry representing the initial input-output measurement highlight
             in the plot. If `None`, this element will not appear in the
             legend. Defaults to `None`.
@@ -690,7 +690,7 @@ def plot_input_output_animation(
             label on the plot. Default is True.
         display_control_text (bool): Whether to display the `control_text`
             label on the plot. Default is True.
-        figsize (Tuple[float, float]): The (width, height) dimensions of the
+        figsize (tuple[float, float]): The (width, height) dimensions of the
             created Matplotlib figure.
         dpi (int): The DPI resolution of the figure.
         interval (float): The time between frames in milliseconds. Defaults
@@ -704,8 +704,8 @@ def plot_input_output_animation(
             properties for customizing the plot legend (e.g., fontsize, loc,
             handlelength). If not provided, Matplotlib's default legend
             properties will be used.
-        title (Optional[str]): The title for the created plot figure. If
-            `None`, no title will be displayed. Defaults to `None`.
+        title (str | None): The title for the created plot figure. If `None`,
+            no title will be displayed. Defaults to `None`.
 
     Returns:
         FuncAnimation: A Matplotlib `FuncAnimation` object that animates the
@@ -765,24 +765,24 @@ def plot_input_output_animation(
     )
 
     # Define input-output line lists
-    u_lines: List[Line2D] = []
-    y_lines: List[Line2D] = []
+    u_lines: list[Line2D] = []
+    y_lines: list[Line2D] = []
 
     # Define initial measurement rectangles and texts lists
-    u_rects: List[Rectangle] = []
-    u_right_rect_lines: List[Line2D] = []
-    u_left_rect_lines: List[Line2D] = []
-    u_init_texts: List[Text] = []
-    u_control_texts: List[Text] = []
-    y_rects: List[Rectangle] = []
-    y_right_rect_lines: List[Line2D] = []
-    y_left_rect_lines: List[Line2D] = []
-    y_init_texts: List[Text] = []
-    y_control_texts: List[Text] = []
+    u_rects: list[Rectangle] = []
+    u_right_rect_lines: list[Line2D] = []
+    u_left_rect_lines: list[Line2D] = []
+    u_init_texts: list[Text] = []
+    u_control_texts: list[Text] = []
+    y_rects: list[Rectangle] = []
+    y_right_rect_lines: list[Line2D] = []
+    y_left_rect_lines: list[Line2D] = []
+    y_init_texts: list[Text] = []
+    y_control_texts: list[Text] = []
 
     # Define y-axis center
-    u_y_axis_centers: List[float] = []
-    y_y_axis_centers: List[float] = []
+    u_y_axis_centers: list[float] = []
+    y_y_axis_centers: list[float] = []
 
     # Initialize input plot elements
     for i in range(m):
@@ -962,7 +962,7 @@ def plot_input_output_animation(
 def initialize_data_animation(
     axis: Axes,
     data: np.ndarray,
-    setpoint: Optional[np.ndarray],
+    setpoint: np.ndarray | None,
     index: int,
     data_line_params: dict[str, Any],
     setpoint_line_params: dict[str, Any],
@@ -974,16 +974,16 @@ def initialize_data_animation(
     control_text: str,
     fontsize: int,
     legend_params: dict[str, Any],
-    lines: List[Line2D],
-    rects: List[Rectangle],
-    right_rect_lines: List[Line2D],
-    left_rect_lines: List[Line2D],
-    init_texts: List[Text],
-    control_texts: List[Text],
-    y_axis_centers: List[float],
-    bounds: Optional[Tuple[float, float]] = None,
-    initial_steps: Optional[int] = None,
-    initial_steps_label: Optional[str] = None,
+    lines: list[Line2D],
+    rects: list[Rectangle],
+    right_rect_lines: list[Line2D],
+    left_rect_lines: list[Line2D],
+    init_texts: list[Text],
+    control_texts: list[Text],
+    y_axis_centers: list[float],
+    bounds: tuple[float, float] | None = None,
+    initial_steps: int | None = None,
+    initial_steps_label: str | None = None,
     continuous_updates: bool = False,
     legend_loc: str = "best",
 ) -> None:
@@ -1001,8 +1001,8 @@ def initialize_data_animation(
     Args:
         axis (Axes): The Matplotlib axis object to plot on.
         data (np.ndarray): An array containing data to be plotted.
-        setpoint (Optional[float]): The setpoint value for the data. If
-            `None`, a setpoint line will not be plotted.
+        setpoint (float | None): The setpoint value for the data. If `None`, a
+            setpoint line will not be plotted.
         index (int): The index of the data used for labeling purposes (e.g.,
             "u_1", "u_2"). If set to -1, subscripts will not be added to
             labels.
@@ -1030,32 +1030,32 @@ def initialize_data_animation(
             for customizing the plot legend (e.g., fontsize, loc,
             handlelength). If the 'loc' key is present in the dictionary, it
             overrides the `legend_loc` value.
-        lines (List[Line2D]): The list where the initialized plot lines will
+        lines (list[Line2D]): The list where the initialized plot lines will
             be stored.
-        rects (List[Rectangle]): The list where the initialized rectangles
+        rects (list[Rectangle]): The list where the initialized rectangles
             representing the initial measurement region will be stored.
-        right_rect_lines (List[Line2D]): The list where the initialized
+        right_rect_lines (list[Line2D]): The list where the initialized
             vertical lines representing the upper boundary of the initial
             measurement region will be stored.
-        left_rect_lines (List[Line2D]): The list where the initialized
+        left_rect_lines (list[Line2D]): The list where the initialized
             vertical lines representing the lower boundary of the initial
             measurement region will be stored.
-        init_texts (List[Text]): The list where the initialized initial
+        init_texts (list[Text]): The list where the initialized initial
             measurement label texts will be stored.
-        control_texts (List[Text]): The list where the initialized control
+        control_texts (list[Text]): The list where the initialized control
             label texts will be stored.
-        y_axis_centers (List[float]): The list where the y-axis center from
+        y_axis_centers (list[float]): The list where the y-axis center from
             the adjusted axis will be stored.
-        bounds (Optional[Tuple[float, float]]): A tuple (lower_bound,
-            upper_bound) specifying the bounds of the data to be plotted. If
-            provided, horizontal lines representing these bounds will be
-            plotted. Defaults to `None`.
-        initial_steps (Optional[int]): The number of initial time steps during
+        bounds (tuple[float, float] | None): A tuple (lower_bound, upper_bound)
+            specifying the bounds of the data to be plotted. If provided,
+            horizontal lines representing these bounds will be plotted.
+            Defaults to `None`.
+        initial_steps (int | None): The number of initial time steps during
             which input-output measurements were taken for the data-driven
             characterization of the system. This highlights the initial
             measurement period in the plot. If `None`, no special highlighting
             will be applied. Defaults to `None`.
-        initial_steps_label (Optional[str]): Label text to use for the legend
+        initial_steps_label (str | None): Label text to use for the legend
             entry representing the initial input-output measurement highlight
             in the plot. If `None`, this element will not appear in the
             legend. Defaults to `None`.
@@ -1225,13 +1225,13 @@ def update_data_animation(
     data: np.ndarray,
     data_length: int,
     points_per_frame: int,
-    initial_steps: Optional[int],
+    initial_steps: int | None,
     continuous_updates: bool,
     line: Line2D,
     rect: Rectangle,
     y_axis_center: float,
     right_rect_line: Line2D,
-    left_rect_line: Optional[Line2D],
+    left_rect_line: Line2D | None,
     init_text_obj: Text,
     control_text_obj: Text,
     display_initial_text: bool,
@@ -1255,7 +1255,7 @@ def update_data_animation(
         data_length (int): The length of the `data` array.
         points_per_frame (int): The number of data points shown per animation
             frame.
-        initial_steps (Optional[int]): The number of initial time steps during
+        initial_steps (int| None): The number of initial time steps during
             which input-output measurements were taken for the data-driven
             characterization of the system. This highlights the initial
             measurement period in the plot.
@@ -1268,8 +1268,8 @@ def update_data_animation(
         y_axis_center (float): The y-axis center of the plot axis.
         right_rect_line (Line2D): The line object representing the upper
             boundary of the initial measurement region.
-        left_rect_line (Optional[Line2D]): The line object representing the
-            lower boundary of the initial measurement region.
+        left_rect_line (Line2D | None]): The line object representing the lower
+            boundary of the initial measurement region.
         init_text_obj (Text): The text object containing the initial
             measurement period label.
         control_text_obj (Text): The text object containing the control period
@@ -1375,22 +1375,22 @@ def save_animation(
 
 def get_padded_limits(
     X: np.ndarray,
-    X_s: Optional[np.ndarray] = None,
+    X_s: np.ndarray | None = None,
     pad_percentage: float = 0.05,
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     """
     Get the minimum and maximum limits from two data sequences extended by
     a specified percentage of the combined data range.
 
     Args:
         X (np.ndarray): First data array.
-        X_s (Optional[np.ndarray], optional): Second data array. If `None`,
-            only `X` is considered. Defaults to `None`.
-        pad_percentage (float, optional): The percentage of the data range
-            to be used as padding. Defaults to 0.05.
+        X_s (np.ndarray | None): Second data array. If `None`, only `X` is
+            considered. Defaults to `None`.
+        pad_percentage (float): The percentage of the data range to be used
+            as padding. Defaults to 0.05.
 
     Returns:
-        Tuple[float, float]: A tuple containing padded minimum and maximum
+        tuple[float, float]: A tuple containing padded minimum and maximum
             limits for the combined data from `X` and `X_s`.
     """
     # Get minimum and maximum limits from data sequences
@@ -1442,7 +1442,7 @@ def get_text_width_in_data(
 def filter_and_reorder_legend(
     axis: Axes,
     legend_params: dict[str, Any],
-    end_labels_list: Optional[List[str]] = None,
+    end_labels_list: list[str] | None = None,
 ) -> None:
     """
     Remove duplicate entries from the legend of a Matplotlib axis. Optionally,
@@ -1457,11 +1457,11 @@ def filter_and_reorder_legend(
         legend_params (dict[str, Any]): A dictionary of Matplotlib properties
             for customizing the plot legend (e.g., fontsize, loc,
             handlelength).
-        end_labels_list (Optional[List[str]]): A list of labels to move to
-            the end of the legend. Labels are moved in the order provided,
-            with the last label in the list becoming the final legend entry.
-            If not provided, the legend labels will not be reordered. Defaults
-            to `None`.
+        end_labels_list (list[str] | None): A list of labels to move to the end
+            of the legend. Labels are moved in the order provided, with the
+            last label in the list becoming the final legend entry. If not
+            provided, the legend labels will not be reordered. Defaults to
+            `None`.
     """
     # Initialize `last_labels_list` if not provided
     if end_labels_list is None:
@@ -1484,11 +1484,11 @@ def filter_and_reorder_legend(
 def create_input_output_figure(
     m: int,
     p: int,
-    figsize: Tuple[float, float],
+    figsize: tuple[float, float],
     dpi: int,
     fontsize: int,
-    title: Optional[str] = None,
-) -> Tuple[Figure, List[Axes], List[Axes]]:
+    title: str | None = None,
+) -> tuple[Figure, list[Axes], list[Axes]]:
     """
     Create a Matplotlib figure with two rows of subplots: one for control
     inputs and one for system outputs, and return the created figure and
@@ -1501,18 +1501,18 @@ def create_input_output_figure(
     Args:
         m (int): The number of control inputs (subplots in the first row).
         p (int): The number of system outputs (subplots in the second row).
-        figsize (Tuple[float, float]): The (width, height) dimensions of the
+        figsize (tuple[float, float]): The (width, height) dimensions of the
             created Matplotlib figure.
         dpi (int): The DPI resolution of the figure.
         fontsize (int): The fontsize for suptitles.
-        title (Optional[str]): The title for the overall figure. If `None`,
-            no title will be added. Defaults to `None`.
+        title (str | None): The title for the overall figure. If `None`, no
+            title will be added. Defaults to `None`.
 
     Returns:
-        Tuple: A tuple containing:
+        tuple: A tuple containing:
             - Figure: The created Matplotlib figure.
-            - List[Axes]: A list of axes for control inputs subplots.
-            - List[Axes]: A list of axes for system outputs subplots.
+            - list[Axes]: A list of axes for control inputs subplots.
+            - list[Axes]: A list of axes for system outputs subplots.
     """
     # Create figure
     fig = plt.figure(num=title, layout="constrained", figsize=figsize, dpi=dpi)

--- a/direct_data_driven_mpc/utilities/hankel_matrix.py
+++ b/direct_data_driven_mpc/utilities/hankel_matrix.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
@@ -57,7 +55,7 @@ def hankel_matrix(X: np.ndarray, L: int) -> np.ndarray:
 
 def evaluate_persistent_excitation(
     X: np.ndarray, order: int
-) -> Tuple[int, bool]:
+) -> tuple[int, bool]:
     """
     Evaluate whether a data sequence `X` is persistently exciting of a given
     order based on the rank of its Hankel matrix. The matrix `X` consists of a
@@ -72,7 +70,7 @@ def evaluate_persistent_excitation(
         order (int): The order of persistent excitation to evaluate.
 
     Returns:
-        Tuple[int, bool]: A tuple containing the rank of the Hankel matrix and
+        tuple[int, bool]: A tuple containing the rank of the Hankel matrix and
             a boolean indicating whether `X` is persistently exciting of the
             given order.
     """

--- a/examples/lti_control/paper_reproduction_utils.py
+++ b/examples/lti_control/paper_reproduction_utils.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -136,8 +136,8 @@ def create_data_driven_mpc_controllers_reproduction(
     controller_config: LTIDataDrivenMPCParamsDictType,
     u_d: np.ndarray,
     y_d: np.ndarray,
-    data_driven_mpc_controller_schemes: List[DataDrivenMPCScheme],
-) -> List[LTIDataDrivenMPCController]:
+    data_driven_mpc_controller_schemes: list[DataDrivenMPCScheme],
+) -> list[LTIDataDrivenMPCController]:
     """
     Create `LTIDataDrivenMPCController` instances for a specified list of
     Data-Driven MPC schemes.
@@ -163,12 +163,12 @@ def create_data_driven_mpc_controllers_reproduction(
         y_d (np.ndarray): An array of shape `(N, p)` representing the system's
             output response to `u_d`. `N` is the trajectory length and `p` is
             the number of system outputs.
-        data_driven_mpc_controller_schemes (List[DataDrivenMPCScheme]): A list
+        data_driven_mpc_controller_schemes (list[DataDrivenMPCScheme]): A list
             of `DataDrivenMPCScheme` objects, which represent Robust
             Data-Driven MPC schemes based on the paper example from [1].
 
     Returns:
-        List[LTIDataDrivenMPCController]: A list of
+        list[LTIDataDrivenMPCController]: A list of
             `LTIDataDrivenMPCController` instances, which represent
             Data-Driven MPC controllers designed for Linear Time-Invariant
             (LTI) systems, based on specified configurations.
@@ -224,11 +224,11 @@ def create_data_driven_mpc_controllers_reproduction(
 
 def simulate_data_driven_mpc_control_loops_reproduction(
     system_model: LTIModel,
-    data_driven_mpc_controllers: List[LTIDataDrivenMPCController],
+    data_driven_mpc_controllers: list[LTIDataDrivenMPCController],
     n_steps: int,
     np_random: Generator,
     verbose: int,
-) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """
     Simulate multiple Data-Driven MPC control loops applied to a system and
     return the resulting input-output data sequences for each controller.
@@ -242,7 +242,7 @@ def simulate_data_driven_mpc_control_loops_reproduction(
     Args:
         system_model (LTIModel): An `LTIModel` instance representing a Linear
             Time-Invariant (LTI) system.
-        data_driven_mpc_controllers (List[LTIDataDrivenMPCController]): A
+        data_driven_mpc_controllers (list[LTIDataDrivenMPCController]): A
             list of `LTIDataDrivenMPCController` instances representing the
             Data-Driven MPC controllers to be simulated.
         n_steps (int): The number of time steps for the simulation.
@@ -252,7 +252,7 @@ def simulate_data_driven_mpc_control_loops_reproduction(
             2 = detailed output.
 
     Returns:
-        Tuple[List[np.ndarray], List[np.ndarray]]: A tuple containing:
+        tuple[list[np.ndarray], list[np.ndarray]]: A tuple containing:
             - A list of arrays, each of shape `(n_steps, m)`, representing the
                 optimal control inputs applied to the system for each
                 controller, where `m` is the number of control inputs.
@@ -294,19 +294,19 @@ def simulate_data_driven_mpc_control_loops_reproduction(
 
 
 def plot_input_output_reproduction(
-    data_driven_mpc_controller_schemes: List[DataDrivenMPCScheme],
-    u_data: List[np.ndarray],
-    y_data: List[np.ndarray],
+    data_driven_mpc_controller_schemes: list[DataDrivenMPCScheme],
+    u_data: list[np.ndarray],
+    y_data: list[np.ndarray],
     u_s: np.ndarray,
     y_s: np.ndarray,
-    u_ylimits_list: Optional[List[Tuple[float, float]]],
-    y_ylimits_list: Optional[List[Tuple[float, float]]],
+    u_ylimits_list: list[tuple[float, float]] | None,
+    y_ylimits_list: list[tuple[float, float]] | None,
     setpoints_line_params: dict[str, Any] | None = None,
     legend_params: dict[str, Any] | None = None,
-    figsize: Tuple[int, int] = (14, 8),
+    figsize: tuple[int, int] = (14, 8),
     dpi: int = 300,
     fontsize: int = 12,
-    title: Optional[str] = None,
+    title: str | None = None,
 ) -> None:
     """
     Plot input-output data with setpoints from multiple Data-Driven MPC
@@ -319,22 +319,22 @@ def plot_input_output_reproduction(
     for each controller scheme.
 
     Args:
-        data_driven_mpc_controller_schemes (List[DataDrivenMPCScheme]): A list
+        data_driven_mpc_controller_schemes (list[DataDrivenMPCScheme]): A list
             of `DataDrivenMPCScheme` objects representing Robust Data-Driven
             MPC schemes.
-        u_data (List[np.ndarray]): A list of arrays containing control input
+        u_data (list[np.ndarray]): A list of arrays containing control input
             data from each controller scheme simulation.
-        y_data (List[np.ndarray]): A list of arrays containing system output
+        y_data (list[np.ndarray]): A list of arrays containing system output
             data from each controller scheme simulation.
         u_s (np.ndarray): An array of shape `(m, 1)` containing the `m` input
             setpoint values considered for the controller simulations.
         y_s (np.ndarray): An array of shape `(p, 1)` containing the `p` output
             setpoint values considered for the controller simulations.
-        u_ylimits_list (Optional[List[Tuple[float, float]]]): A list of tuples
+        u_ylimits_list (list[tuple[float, float]] | None): A list of tuples
             (lower_limit, upper_limit) specifying the Y-axis limits for each
             input subplot. If `None`, the Y-axis limits will be determined
             automatically.
-        y_ylimits_list (Optional[List[Tuple[float, float]]]): A list of tuples
+        y_ylimits_list (list[tuple[float, float]] | None): A list of tuples
             (lower_limit, upper_limit) specifying the Y-axis limits for each
             output subplot. If `None`, the Y-axis limits will be determined
             automatically.
@@ -346,11 +346,11 @@ def plot_input_output_reproduction(
             properties for customizing the plot legends (e.g., fontsize,
             loc, handlelength). If not provided, Matplotlib's default legend
             properties will be used.
-        figsize (Tuple[int, int]): The (width, height) dimensions of the
+        figsize (tuple[int, int]): The (width, height) dimensions of the
             created Matplotlib figure.
         dpi (int): The DPI resolution of the figure.
         fontsize (int): The fontsize for labels, legends and axes ticks.
-        title (Optional[str]): The title for the created plot figure.
+        title (str | None): The title for the created plot figure.
     """
     # Retrieve number of input and output data sequences and their length
     m = u_data[0].shape[1]  # Number of inputs


### PR DESCRIPTION
This PR modernizes type annotations in the project following [PEP 585](https://peps.python.org/pep-0585/) and [PEP 604](https://peps.python.org/pep-0604/).

### Key changes:
- Replaced `typing.List` and `typing.Tuple` with the built-in generic types `list`, `tuple`.
- Replaced `typing.Union[A, B]` with `A | B`.
- Replaced `typing.Optional[...]` with `... | None`.
- Updated docstrings to reflect these changes.
