### PR TITLE
Rename Data-Driven MPC config type variables for clarity

### DIFF
--- a/direct_data_driven_mpc/utilities/controller/controller_creation.py
+++ b/direct_data_driven_mpc/utilities/controller/controller_creation.py
@@ -7,13 +7,13 @@ from direct_data_driven_mpc.nonlinear_data_driven_mpc_controller import (
     NonlinearDataDrivenMPCController,
 )
 from direct_data_driven_mpc.utilities.controller.controller_params import (
-    LTIDataDrivenMPCParamsDictType,
-    NonlinearDataDrivenMPCParamsDictType,
+    LTIDataDrivenMPCParams,
+    NonlinearDataDrivenMPCParams,
 )
 
 
 def create_lti_data_driven_mpc_controller(
-    controller_config: LTIDataDrivenMPCParamsDictType,
+    controller_config: LTIDataDrivenMPCParams,
     u_d: np.ndarray,
     y_d: np.ndarray,
     use_terminal_constraints: bool = True,
@@ -24,9 +24,9 @@ def create_lti_data_driven_mpc_controller(
     trajectory data measured from a system.
 
     Args:
-        controller_config (LTIDataDrivenMPCParamsDictType): A dictionary
-            containing configuration parameters for a Data-Driven MPC
-            controller designed for Linear Time-Invariant (LTI) systems.
+        controller_config (LTIDataDrivenMPCParams): A dictionary containing
+            configuration parameters for a Data-Driven MPC controller designed
+            for Linear Time-Invariant (LTI) systems.
         u_d (np.ndarray): An array of shape `(N, m)` representing a
             persistently exciting input sequence used to generate output data
             from the system. `N` is the trajectory length and `m` is the
@@ -105,7 +105,7 @@ def create_lti_data_driven_mpc_controller(
 
 
 def create_nonlinear_data_driven_mpc_controller(
-    controller_config: NonlinearDataDrivenMPCParamsDictType,
+    controller_config: NonlinearDataDrivenMPCParams,
     u: np.ndarray,
     y: np.ndarray,
 ) -> NonlinearDataDrivenMPCController:
@@ -115,7 +115,7 @@ def create_nonlinear_data_driven_mpc_controller(
     trajectory data measured from a system.
 
     Args:
-        controller_config (NonlinearDataDrivenMPCParamsDictType): A dictionary
+        controller_config (NonlinearDataDrivenMPCParams): A dictionary
             containing configuration parameters for a Data-Driven MPC
             controller designed for Nonlinear systems.
         u (np.ndarray): An array of shape `(N, m)` representing a

--- a/direct_data_driven_mpc/utilities/controller/controller_params.py
+++ b/direct_data_driven_mpc/utilities/controller/controller_params.py
@@ -38,7 +38,7 @@ AlphaRegTypesMap = {
 
 
 # Define dictionary type hints for Data-Driven MPC controller parameters
-class LTIDataDrivenMPCParamsDictType(TypedDict, total=False):
+class LTIDataDrivenMPCParams(TypedDict, total=False):
     n: int  # Estimated system order
 
     N: int  # Initial input-output trajectory length
@@ -64,7 +64,7 @@ class LTIDataDrivenMPCParamsDictType(TypedDict, total=False):
     y_s: np.ndarray  # System output setpoint
 
 
-class NonlinearDataDrivenMPCParamsDictType(TypedDict, total=False):
+class NonlinearDataDrivenMPCParams(TypedDict, total=False):
     n: int  # Estimated system order
 
     N: int  # Initial input-output trajectory length
@@ -97,9 +97,7 @@ class NonlinearDataDrivenMPCParamsDictType(TypedDict, total=False):
     n_mpc_step: int  # Number of consecutive applications of the optimal input
 
 
-DataDrivenMPCParamsType = (
-    LTIDataDrivenMPCParamsDictType | NonlinearDataDrivenMPCParamsDictType
-)
+DataDrivenMPCParams = LTIDataDrivenMPCParams | NonlinearDataDrivenMPCParams
 
 
 # Define lists of required Data-Driven controller parameters
@@ -150,7 +148,7 @@ def get_lti_data_driven_mpc_controller_params(
     m: int,
     p: int,
     verbose: int = 0,
-) -> LTIDataDrivenMPCParamsDictType:
+) -> LTIDataDrivenMPCParams:
     """
     Load and initialize parameters for a Data-Driven MPC controller designed
     for Linear Time-Invariant (LTI) systems from a YAML configuration file.
@@ -170,9 +168,9 @@ def get_lti_data_driven_mpc_controller_params(
                 output, 2 = detailed output.
 
     Returns:
-        LTIDataDrivenMPCParamsDictType: A dictionary of configuration
-            parameters for a Data-Driven MPC controller designed for Linear
-            Time-Invariant (LTI) systems.
+        LTIDataDrivenMPCParams: A dictionary of configuration parameters for a
+            Data-Driven MPC controller designed for Linear Time-Invariant (LTI)
+            systems.
 
     Raises:
         FileNotFoundError: If the YAML configuration file is not found.
@@ -206,7 +204,7 @@ def get_lti_data_driven_mpc_controller_params(
             )
 
     # Initialize Data-Driven MPC controller parameter dict
-    dd_mpc_params: LTIDataDrivenMPCParamsDictType = {}
+    dd_mpc_params: LTIDataDrivenMPCParams = {}
 
     # --- Define initial Input-Output data generation parameters ---
     # Persistently exciting input range
@@ -312,7 +310,7 @@ def get_nonlinear_data_driven_mpc_controller_params(
     m: int,
     p: int,
     verbose: int = 0,
-) -> NonlinearDataDrivenMPCParamsDictType:
+) -> NonlinearDataDrivenMPCParams:
     """
     Load and initialize parameters for a Data-Driven MPC controller designed
     for Nonlinear systems from a YAML configuration file.
@@ -332,9 +330,8 @@ def get_nonlinear_data_driven_mpc_controller_params(
                 output, 2 = detailed output.
 
     Returns:
-        NonlinearDataDrivenMPCParamsDictType: A dictionary of configuration
-            parameters for a Data-Driven MPC controller designed for Nonlinear
-            systems.
+        NonlinearDataDrivenMPCParams: A dictionary of configuration parameters
+            for a Data-Driven MPC controller designed for Nonlinear systems.
 
     Raises:
         FileNotFoundError: If the YAML configuration file is not found.
@@ -367,7 +364,7 @@ def get_nonlinear_data_driven_mpc_controller_params(
             )
 
     # Initialize Data-Driven MPC controller parameter dict
-    dd_mpc_params: NonlinearDataDrivenMPCParamsDictType = {}
+    dd_mpc_params: NonlinearDataDrivenMPCParams = {}
 
     # --- Define initial Input-Output data generation parameters ---
     # Persistently exciting input range
@@ -591,7 +588,7 @@ def get_weights_list_from_param(
 
 
 def print_initialization_details(
-    dd_mpc_params: DataDrivenMPCParamsType,
+    dd_mpc_params: DataDrivenMPCParams,
     cost_horizon: int,
     verbose: int,
     controller_label: str = "LTI",
@@ -600,7 +597,7 @@ def print_initialization_details(
     Print controller parameter initialization details.
 
     Args:
-        dd_mpc_params (DataDrivenMPCParamsType): A dictionary of configuration
+        dd_mpc_params (DataDrivenMPCParams): A dictionary of configuration
             parameters for a Data-Driven MPC controller.
         cost_horizon (int): The total length of the prediction horizon
             considered in the MPC cost function (`L` for LTI and `L + n + 1`

--- a/direct_data_driven_mpc/utilities/controller/initial_data_generation.py
+++ b/direct_data_driven_mpc/utilities/controller/initial_data_generation.py
@@ -2,8 +2,8 @@ import numpy as np
 from numpy.random import Generator
 
 from direct_data_driven_mpc.utilities.controller.controller_params import (
-    DataDrivenMPCParamsType,
-    LTIDataDrivenMPCParamsDictType,
+    DataDrivenMPCParams,
+    LTIDataDrivenMPCParams,
 )
 from direct_data_driven_mpc.utilities.models.lti_model import LTIModel
 from direct_data_driven_mpc.utilities.models.nonlinear_model import (
@@ -13,7 +13,7 @@ from direct_data_driven_mpc.utilities.models.nonlinear_model import (
 
 def randomize_initial_system_state(
     system_model: LTIModel,
-    controller_config: LTIDataDrivenMPCParamsDictType,
+    controller_config: LTIDataDrivenMPCParams,
     np_random: Generator,
 ) -> np.ndarray:
     """
@@ -34,10 +34,10 @@ def randomize_initial_system_state(
     Args:
         system_model (LTIModel): An `LTIModel` instance representing a Linear
             Time-Invariant (LTI) system.
-        controller_config (LTIDataDrivenMPCParamsDictType): A dictionary
-            containing parameters for a Data-Driven MPC controller designed
-            for Linear Time-Invariant (LTI) systems, including the range of
-            the persistently exciting input (`u_range`).
+        controller_config (LTIDataDrivenMPCParams): A dictionary containing
+            parameters for a Data-Driven MPC controller designed for Linear
+            Time-Invariant (LTI) systems, including the range of the
+            persistently exciting input (`u_range`).
         np_random (Generator): A Numpy random number generator for generating
             the random initial system state, persistently exciting input, and
             system output noise.
@@ -87,7 +87,7 @@ def randomize_initial_system_state(
 
 def generate_initial_input_output_data(
     system_model: LTIModel | NonlinearSystem,
-    controller_config: DataDrivenMPCParamsType,
+    controller_config: DataDrivenMPCParams,
     np_random: Generator,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
@@ -105,7 +105,7 @@ def generate_initial_input_output_data(
         system_model (LTIModel | NonlinearSystem): An instance of `LTIModel`,
             representing a Linear Time-Invariant (LTI) system, or
             `NonlinearSystem`, representing a Nonlinear system.
-        controller_config (DataDrivenMPCParamsType): A dictionary containing
+        controller_config (DataDrivenMPCParams): A dictionary containing
             parameters for a Data-Driven MPC controller designed for Linear
             Time-Invariant (LTI) or Nonlinear systems. Includes the initial
             input-output trajectory length (`N`) and the range of the
@@ -153,7 +153,7 @@ def generate_initial_input_output_data(
 
 def simulate_n_input_output_measurements(
     system_model: LTIModel,
-    controller_config: LTIDataDrivenMPCParamsDictType,
+    controller_config: LTIDataDrivenMPCParams,
     np_random: Generator,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
@@ -177,10 +177,10 @@ def simulate_n_input_output_measurements(
     Args:
         system_model (LTIModel): An `LTIModel` instance representing a Linear
             Time-Invariant (LTI) system.
-        controller_config (LTIDataDrivenMPCParamsDictType): A dictionary
-            containing parameters for a Data-Driven MPC controller designed
-            for Linear Time-Invariant (LTI) systems, including the estimated
-            system order (`n`) and the control input setpoint (`u_s`).
+        controller_config (LTIDataDrivenMPCParams): A dictionary containing
+            parameters for a Data-Driven MPC controller designed for Linear
+            Time-Invariant (LTI) systems, including the estimated system order
+            (`n`) and the control input setpoint (`u_s`).
         np_random (Generator): A Numpy random number generator for generating
             random noise for the system's output.
 

--- a/examples/lti_control/paper_reproduction_utils.py
+++ b/examples/lti_control/paper_reproduction_utils.py
@@ -13,7 +13,7 @@ from direct_data_driven_mpc.utilities.controller.controller_creation import (
     create_lti_data_driven_mpc_controller,
 )
 from direct_data_driven_mpc.utilities.controller.controller_params import (
-    LTIDataDrivenMPCParamsDictType,
+    LTIDataDrivenMPCParams,
 )
 from direct_data_driven_mpc.utilities.controller.data_driven_mpc_sim import (
     simulate_lti_data_driven_mpc_control_loop,
@@ -133,7 +133,7 @@ def get_equilibrium_state_from_output(
 
 
 def create_data_driven_mpc_controllers_reproduction(
-    controller_config: LTIDataDrivenMPCParamsDictType,
+    controller_config: LTIDataDrivenMPCParams,
     u_d: np.ndarray,
     y_d: np.ndarray,
     data_driven_mpc_controller_schemes: list[DataDrivenMPCScheme],
@@ -152,10 +152,10 @@ def create_data_driven_mpc_controllers_reproduction(
         controller schemes presented in the paper example from [1].
 
     Args:
-        controller_config (LTIDataDrivenMPCParamsDictType): A dictionary
-            containing configuration parameters for a Data-Driven MPC
-            controller designed for Linear Time-Invariant (LTI) systems. Used
-            as a base configuration.
+        controller_config (LTIDataDrivenMPCParams): A dictionary containing
+            configuration parameters for a Data-Driven MPC controller designed
+            for Linear Time-Invariant (LTI) systems. Used as a base
+            configuration.
         u_d (np.ndarray): An array of shape `(N, m)` representing a
             persistently exciting input sequence used to generate output data
             from the system. `N` is the trajectory length and `m` is the


### PR DESCRIPTION
This PR renames various Data-Driven MPC config type variables to improve clarity and consistency.

### Key changes:
- Renamed `LTIDataDrivenMPCParamsDictType` to `LTIDataDrivenMPCParams`.
- Renamed `NonlinearDataDrivenMPCParamsDictType` to `NonlinearDataDrivenMPCParams`.
- Renamed `DataDrivenMPCParamsType` to `DataDrivenMPCParams`.
- Updated all references, type hints, and docstrings to reflect the new names.