### PR TITLE
Parallelize CI testing

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           name: coverage-data-unit
           path: .coverage.*
+          include-hidden-files: true
 
   integration_tests:
     runs-on: ubuntu-latest
@@ -92,6 +93,7 @@ jobs:
         with:
           name: "coverage-data-${{ matrix.test_type }}"
           path: .coverage.*
+          include-hidden-files: true
 
   coverage_report:
     needs: [code_quality_unit_tests, integration_tests]

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -8,7 +8,7 @@ on:
     branches: ["main"]
 
 jobs:
-  ci_workflow:
+  code_quality_unit_tests:
     runs-on: ubuntu-latest
     container: python:3.12-slim-bullseye
     steps:
@@ -44,7 +44,79 @@ jobs:
       - name: YAML Lint
         run: yamllint --strict .
 
-      - name: Run tests with coverage
+      - name: Run unit tests with coverage
         run: |
-          coverage run -m pytest --maxfail=2 --disable-warnings
+          coverage run --parallel-mode -m pytest \
+            --maxfail=2 \
+            --disable-warnings \
+            -m "not lti_integration and not nonlinear_integration"
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-unit
+          path: .coverage.*
+
+  integration_tests:
+    runs-on: ubuntu-latest
+    container: python:3.12-slim-bullseye
+    strategy:
+      matrix:
+        test_type: [lti_integration, nonlinear_integration]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ffmpeg
+        run: |
+          apt-get update && \
+          apt-get install -y ffmpeg
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --default-timeout=60 --retries=5 -r requirements-ci.txt
+
+      - name: Install project package in editable mode
+        run: |
+          pip install -e .
+
+      - name: Run integration test with coverage - ${{ matrix.test_type }}
+        run: |
+          coverage run --parallel-mode -m pytest \
+            --disable-warnings \
+            -m "${{ matrix.test_type }}"
+
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: "coverage-data-${{ matrix.test_type }}"
+          path: .coverage.*
+
+  coverage_report:
+    needs: [code_quality_unit_tests, integration_tests]
+    runs-on: ubuntu-latest
+    container: python:3.12-slim-bullseye
+    steps:
+      - name: Download unit test coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-data-unit
+
+      - name: Download LTI integration test coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-data-lti_integration
+
+      - name: Download nonlinear integration test coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-data-nonlinear_integration
+
+      - name: Install coverage
+        run: pip install coverage
+
+      - name: Combine and show coverage report
+        run: |
+          coverage combine
           coverage report

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -100,6 +100,9 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3.12-slim-bullseye
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download unit test coverage data
         uses: actions/download-artifact@v4
         with:

--- a/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
+++ b/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
@@ -1187,10 +1187,7 @@ class NonlinearDataDrivenMPCController:
         Store the previous optimal value of `alpha` for regularization in
         subsequent MPC iterations.
         """
-        self.prev_alpha_val = self.alpha.value  #  type: ignore[assignment]
-        # Note:
-        # mypy [assignment] is ignored since `alpha.value` could only be `None`
-        # if `alpha` were a sparse matrix, which is not the case in our system
+        self.prev_alpha_val = self.alpha.value
 
     def get_du_value_at_step(self, n_step: int = 0) -> np.ndarray | None:
         """

--- a/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
+++ b/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
@@ -1187,7 +1187,10 @@ class NonlinearDataDrivenMPCController:
         Store the previous optimal value of `alpha` for regularization in
         subsequent MPC iterations.
         """
-        self.prev_alpha_val = self.alpha.value
+        self.prev_alpha_val = self.alpha.value  #  type: ignore[assignment]
+        # Note:
+        # mypy [assignment] is ignored since `alpha.value` could only be `None`
+        # if `alpha` were a sparse matrix, which is not the case in our system
 
     def get_du_value_at_step(self, n_step: int = 0) -> np.ndarray | None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,9 @@ warn_unused_ignores = true
 
 [tool.codespell]
 ignore-words-list = "Ot"
+
+[tool.pytest.ini_options]
+markers =[
+  "lti_integration: Integration tests for LTI controller",
+  "nonlinear_integration: Integration tests for nonlinear controller"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ install_types = true
 non_interactive = true
 ignore_missing_imports = true
 disallow_untyped_defs = true
-warn_unused_ignores = true
 
 [tool.codespell]
 ignore-words-list = "Ot"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ from direct_data_driven_mpc.utilities.controller.controller_creation import (
     LTIDataDrivenMPCParams,
     NonlinearDataDrivenMPCParams,
 )
+from direct_data_driven_mpc.utilities.models.nonlinear_model import (
+    NonlinearSystem,
+)
 
 from .mocks import (
     MockLTIDDMPCController,
@@ -127,3 +130,33 @@ def dummy_nonlinear_controller_data() -> tuple[
     # input. This is not always the case.
 
     return (nonlinear_dd_mpc_params, u, y)
+
+
+@pytest.fixture
+def test_nonlinear_system_model() -> NonlinearSystem:
+    """Simple nonlinear system for testing."""
+    eps_max = 0.0
+
+    # Define Dynamics function
+    def cstr_dynamics(x: np.ndarray, u: np.ndarray) -> np.ndarray:
+        x1, x2 = x
+        u1 = u[0]
+
+        x1_new = x1 + 0.1 * (-0.5 * x1 + u1**2)
+        x2_new = x2 + 0.1 * (-0.3 * x2 + u1)
+
+        return np.array([x1_new, x2_new])
+
+    # Define Output function
+    def cstr_output(x: np.ndarray, u: np.ndarray) -> np.ndarray:
+        return x[[1]]
+
+    # Create nonlinear system model
+    return NonlinearSystem(
+        f=cstr_dynamics,
+        h=cstr_output,
+        n=2,
+        m=1,
+        p=1,
+        eps_max=eps_max,
+    )

--- a/tests/test_lti_dd_mpc_integration.py
+++ b/tests/test_lti_dd_mpc_integration.py
@@ -45,6 +45,7 @@ TEST_LTI_DD_MPC_CONFIG_PATH = os.path.join(
 TEST_LTI_DD_MPC_PARAMS_KEY = "test_lti_dd_mpc_params"
 
 
+@pytest.mark.lti_integration
 @pytest.mark.parametrize("n_n_mpc_step", [True, False])
 @pytest.mark.parametrize(
     "controller_type, slack_var_constraint_type",

--- a/tests/test_nonlinear_dd_mpc_integration.py
+++ b/tests/test_nonlinear_dd_mpc_integration.py
@@ -69,6 +69,7 @@ def test_nonlinear_system_model() -> NonlinearSystem:
     )
 
 
+@pytest.mark.nonlinear_integration
 @pytest.mark.parametrize("n_n_mpc_step", [True, False])
 @pytest.mark.parametrize("ext_out_incr_in", [True, False])
 @pytest.mark.parametrize(

--- a/tests/test_nonlinear_dd_mpc_integration.py
+++ b/tests/test_nonlinear_dd_mpc_integration.py
@@ -40,35 +40,6 @@ TEST_NONLINEAR_DD_MPC_CONFIG_PATH = os.path.join(
 TEST_NONLINEAR_DD_MPC_PARAMS_KEY = "test_nonlinear_dd_mpc_params"
 
 
-def test_nonlinear_system_model() -> NonlinearSystem:
-    """Simple nonlinear system for testing."""
-    eps_max = 0.0
-
-    # Define Dynamics function
-    def cstr_dynamics(x: np.ndarray, u: np.ndarray) -> np.ndarray:
-        x1, x2 = x
-        u1 = u[0]
-
-        x1_new = x1 + 0.1 * (-0.5 * x1 + u1**2)
-        x2_new = x2 + 0.1 * (-0.3 * x2 + u1)
-
-        return np.array([x1_new, x2_new])
-
-    # Define Output function
-    def cstr_output(x: np.ndarray, u: np.ndarray) -> np.ndarray:
-        return x[[1]]
-
-    # Create nonlinear system model
-    return NonlinearSystem(
-        f=cstr_dynamics,
-        h=cstr_output,
-        n=2,
-        m=1,
-        p=1,
-        eps_max=eps_max,
-    )
-
-
 @pytest.mark.nonlinear_integration
 @pytest.mark.parametrize("n_n_mpc_step", [True, False])
 @pytest.mark.parametrize("ext_out_incr_in", [True, False])
@@ -80,6 +51,7 @@ def test_nonlinear_dd_mpc_integration(
     alpha_reg_type: AlphaRegType,
     ext_out_incr_in: bool,
     n_n_mpc_step: bool,
+    test_nonlinear_system_model: NonlinearSystem,
     tmp_path: Path,
 ) -> None:
     """
@@ -92,7 +64,7 @@ def test_nonlinear_dd_mpc_integration(
     verbose = 0
 
     # Define system model
-    system_model = test_nonlinear_system_model()
+    system_model = test_nonlinear_system_model
 
     # Load Data-Driven MPC controller parameters from configuration file
     m = system_model.m  # Number of inputs


### PR DESCRIPTION
This PR splits the `ci_workflow` job in the CI workflow into `code_quality_unit_tests`, `integration_tests`, and `coverage_report` to reduce the overall CI workflow execution time.

### Key changes:
- Refactored `ci_workflow.yml` to define the following jobs:
  - `code_quality_unit_tests`: Executes static typing and linting checks, and unit tests.
  - `integration_tests`: Executes integration tests with a matrix strategy.
  - `coverage_report`: Creates the coverage report after test jobs finish their execution.
- Marked integration tests using pytest markers.
