### PR TITLE
Rename variables and parameters

### DIFF
--- a/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
+++ b/direct_data_driven_mpc/nonlinear_data_driven_mpc_controller.py
@@ -130,9 +130,9 @@ class NonlinearDataDrivenMPCController:
             constraints over the prediction horizon.
         U_const_up (np.ndarray): A tiled upper bound for the input trajectory
             constraints over the prediction horizon.
-        Us_const_low (np.ndarray): The lower bound for the input equilibrium
+        Us_const_low (np.ndarray): The lower bound for the equilibrium input
             constraints.
-        Us_const_up (np.ndarray): The upper bound for the input equilibrium
+        Us_const_up (np.ndarray): The upper bound for the equilibrium input
             constraints.
 
     References:
@@ -813,7 +813,7 @@ class NonlinearDataDrivenMPCController:
             input-output equilibrium pair (predicted equilibrium setpoints
             `u_s`, `y_s`) in any minimal realization (last `n` input-output
             predictions, as considered in [2]). Defined by Equation (22d).
-        - **Input**: Constraints both the input equilibrium (predicted input
+        - **Input**: Constraints both the equilibrium input (predicted input
             setpoint `u_s`) and the input trajectory (`ubar`). Defined by
             Equation (22e).
 

--- a/direct_data_driven_mpc/utilities/controller/controller_params.py
+++ b/direct_data_driven_mpc/utilities/controller/controller_params.py
@@ -132,8 +132,8 @@ NONLINEAR_DD_MPC_FILE_PARAMS = [
     "Us",
     "u_range",
     "alpha_reg_type",
-    "lamb_alpha_s",
-    "lamb_sigma_s",
+    "lambda_alpha_s",
+    "lambda_sigma_s",
     "y_r",
     "ext_out_incr_in",
     "update_cost_threshold",
@@ -469,9 +469,9 @@ def get_nonlinear_data_driven_mpc_controller_params(
 
     # Nonlinear MPC parameters for alpha_reg_type = 0 (Approximated)
     # Ridge regularization weight for alpha_s
-    dd_mpc_params["lamb_alpha_s"] = params["lamb_alpha_s"]
+    dd_mpc_params["lamb_alpha_s"] = params["lambda_alpha_s"]
     # Ridge regularization weight for sigma_s
-    dd_mpc_params["lamb_sigma_s"] = params["lamb_sigma_s"]
+    dd_mpc_params["lamb_sigma_s"] = params["lambda_sigma_s"]
 
     # System Output setpoint
     y_r = params["y_r"]

--- a/direct_data_driven_mpc/utilities/controller/controller_params.py
+++ b/direct_data_driven_mpc/utilities/controller/controller_params.py
@@ -143,7 +143,7 @@ NONLINEAR_DD_MPC_FILE_PARAMS = [
 
 def get_lti_data_driven_mpc_controller_params(
     config_file: str,
-    controller_key_value: str,
+    controller_key: str,
     m: int,
     p: int,
     verbose: int = 0,
@@ -159,7 +159,7 @@ def get_lti_data_driven_mpc_controller_params(
 
     Args:
         config_file (str): The path to the YAML configuration file.
-        controller_key_value (str): The key to access the specific controller
+        controller_key (str): The key to access the specific controller
             parameters in the config file.
         m (int): The number of control inputs.
         p (int): The number of system outputs.
@@ -173,8 +173,8 @@ def get_lti_data_driven_mpc_controller_params(
 
     Raises:
         FileNotFoundError: If the YAML configuration file is not found.
-        ValueError: If `controller_key_value` or if required Data-Driven
-            controller parameters are missing in the configuration file.
+        ValueError: If `controller_key` or if required Data-Driven controller
+            parameters are missing in the configuration file.
 
     References:
         [1] J. Berberich, J. Köhler, M. A. Müller and F. Allgöwer,
@@ -185,13 +185,13 @@ def get_lti_data_driven_mpc_controller_params(
     """
     # Load controller parameters from config file
     params = load_yaml_config_params(
-        config_file=config_file, key=controller_key_value
+        config_file=config_file, key=controller_key
     )
 
     if verbose > 1:
         print(
             "    Data-Driven MPC controller parameters loaded from "
-            f"{config_file} with key '{controller_key_value}'"
+            f"{config_file} with key '{controller_key}'"
         )
 
     # Validate that required parameter keys are present
@@ -305,7 +305,7 @@ def get_lti_data_driven_mpc_controller_params(
 
 def get_nonlinear_data_driven_mpc_controller_params(
     config_file: str,
-    controller_key_value: str,
+    controller_key: str,
     m: int,
     p: int,
     verbose: int = 0,
@@ -321,7 +321,7 @@ def get_nonlinear_data_driven_mpc_controller_params(
 
     Args:
         config_file (str): The path to the YAML configuration file.
-        controller_key_value (str): The key to access the specific controller
+        controller_key (str): The key to access the specific controller
             parameters in the config file.
         m (int): The number of control inputs.
         p (int): The number of system outputs.
@@ -334,8 +334,8 @@ def get_nonlinear_data_driven_mpc_controller_params(
 
     Raises:
         FileNotFoundError: If the YAML configuration file is not found.
-        ValueError: If `controller_key_value` or if required Data-Driven
-            controller parameters are missing in the configuration file.
+        ValueError: If `controller_key` or if required Data-Driven controller
+            parameters are missing in the configuration file.
 
     References:
         [2] J. Berberich, J. Köhler, M. A. Müller and F. Allgöwer, "Linear
@@ -345,13 +345,13 @@ def get_nonlinear_data_driven_mpc_controller_params(
     """
     # Load controller parameters from config file
     params = load_yaml_config_params(
-        config_file=config_file, key=controller_key_value
+        config_file=config_file, key=controller_key
     )
 
     if verbose > 1:
         print(
             "    Data-Driven MPC controller parameters loaded from "
-            f"{config_file} with key '{controller_key_value}'"
+            f"{config_file} with key '{controller_key}'"
         )
 
     # Validate that required parameter keys are present

--- a/direct_data_driven_mpc/utilities/models/lti_model.py
+++ b/direct_data_driven_mpc/utilities/models/lti_model.py
@@ -265,37 +265,35 @@ class LTISystemModel(LTIModel):
         configuration file.
     """
 
-    def __init__(
-        self, config_file: str, model_key_value: str, verbose: int = 0
-    ):
+    def __init__(self, config_file: str, model_key: str, verbose: int = 0):
         """
         Initialize a Linear Time-Invariant (LTI) system model by loading
         parameters from a YAML config file.
 
         Args:
             config_file (str): The path to the YAML configuration file.
-            model_key_value (str): The key to access the specific model
-                parameters in the config file.
+            model_key (str): The key to access the specific model parameters in
+                the config file.
             verbose (int): The verbosity level: 0 = no output, 1 = minimal
                 output, 2 = detailed output.
 
         Raises:
             FileNotFoundError: If the YAML configuration file is not found.
-            ValueError: If `model_key_value` or the required matrices (A, B,
-                C, or D) are missing in the configuration file, or if the
-                dimensions of the required matrices are incorrect.
+            ValueError: If `model_key` or the required matrices (A, B, C, or D)
+                are missing in the configuration file, or if the dimensions of
+                the required matrices are incorrect.
         """
         self.verbose = verbose
 
         # Load model parameters from config file
         params = load_yaml_config_params(
-            config_file=config_file, key=model_key_value
+            config_file=config_file, key=model_key
         )
 
         if self.verbose > 1:
             print(
                 f"    Model parameters loaded from {config_file} with key "
-                f"'{model_key_value}'"
+                f"'{model_key}'"
             )
 
         # Validate that required matrix keys are present

--- a/examples/config/controllers/nonlinear_dd_mpc_example_params.yaml
+++ b/examples/config/controllers/nonlinear_dd_mpc_example_params.yaml
@@ -59,8 +59,8 @@ nonlinear_data_driven_mpc_params:
   alpha_reg_type: 1
 
   # Nonlinear MPC parameters for alpha_reg_type = 0 (Approximated)
-  lamb_alpha_s: null  #  Regularization parameter for alpha_s (optional)
-  lamb_sigma_s: null  #  Regularization parameter for sigma_s (optional)
+  lambda_alpha_s: null  #  Regularization parameter for alpha_s (optional)
+  lambda_sigma_s: null  #  Regularization parameter for sigma_s (optional)
 
   y_r: [0.6519]  # System output setpoint
 

--- a/examples/lti_control/lti_dd_mpc_example.py
+++ b/examples/lti_control/lti_dd_mpc_example.py
@@ -75,14 +75,14 @@ default_model_config_file = "four_tank_system_params.yaml"
 default_model_config_path = os.path.join(
     models_config_dir, default_model_config_file
 )
-default_model_key_value = "four_tank_system"
+default_model_key = "four_tank_system"
 
 # Data-Driven MPC controller configuration file
 default_controller_config_file = "lti_dd_mpc_example_params.yaml"
 default_controller_config_path = os.path.join(
     controller_config_dir, default_controller_config_file
 )
-default_controller_key_value = "lti_data_driven_mpc_params"
+default_controller_key = "lti_data_driven_mpc_params"
 
 # Plot parameters configuration file
 plot_params_config_file = "plot_params.yaml"
@@ -145,9 +145,9 @@ def parse_args() -> argparse.Namespace:
         "containing the model parameters.",
     )
     parser.add_argument(
-        "--model_key_value",
+        "--model_key",
         type=str,
-        default=default_model_key_value,
+        default=default_model_key,
         help="The key to access the model parameters in the "
         "configuration file.",
     )
@@ -161,9 +161,9 @@ def parse_args() -> argparse.Namespace:
         "parameters.",
     )
     parser.add_argument(
-        "--controller_key_value",
+        "--controller_key",
         type=str,
-        default=default_controller_key_value,
+        default=default_controller_key,
         help="The key to access the Data-Driven MPC "
         "controller parameters in the configuration file.",
     )
@@ -268,11 +268,11 @@ def main() -> None:
 
     # Model parameters
     model_config_path = args.model_config_path
-    model_key_value = args.model_key_value
+    model_key = args.model_key
 
     # Data-Driven MPC controller parameters
     controller_config_path = args.controller_config_path
-    controller_key_value = args.controller_key_value
+    controller_key = args.controller_key
 
     # Data-Driven MPC controller arguments
     n_mpc_step = args.n_mpc_step
@@ -303,7 +303,7 @@ def main() -> None:
 
     system_model = LTISystemModel(
         config_file=model_config_path,
-        model_key_value=model_key_value,
+        model_key=model_key,
         verbose=verbose,
     )
 
@@ -319,7 +319,7 @@ def main() -> None:
     p = system_model.p  # Number of outputs
     dd_mpc_config = get_lti_data_driven_mpc_controller_params(
         config_file=controller_config_path,
-        controller_key_value=controller_key_value,
+        controller_key=controller_key,
         m=m,
         p=p,
         verbose=verbose,

--- a/examples/lti_control/robust_lti_dd_mpc_reproduction.py
+++ b/examples/lti_control/robust_lti_dd_mpc_reproduction.py
@@ -72,14 +72,14 @@ plot_params_config_dir = os.path.join(examples_dir, "config", "plots")
 # Model configuration file
 model_config_file = "four_tank_system_params.yaml"
 model_config_path = os.path.join(models_config_dir, model_config_file)
-model_key_value = "four_tank_system"
+model_key = "four_tank_system"
 
 # Data-Driven MPC controller configuration file
 controller_config_file = "lti_dd_mpc_example_params.yaml"
 controller_config_path = os.path.join(
     controller_config_dir, controller_config_file
 )
-controller_key_value = "lti_data_driven_mpc_params"
+controller_key = "lti_data_driven_mpc_params"
 
 # Plot parameters configuration file
 plot_params_config_file = "plot_params.yaml"
@@ -176,7 +176,7 @@ def main() -> None:
 
     system_model = LTISystemModel(
         config_file=model_config_path,
-        model_key_value=model_key_value,
+        model_key=model_key,
         verbose=verbose,
     )
 
@@ -192,7 +192,7 @@ def main() -> None:
     p = system_model.p  # Number of outputs
     dd_mpc_config = get_lti_data_driven_mpc_controller_params(
         config_file=controller_config_path,
-        controller_key_value=controller_key_value,
+        controller_key=controller_key,
         m=m,
         p=p,
         verbose=verbose,

--- a/examples/nonlinear_control/nonlinear_cstr_model.py
+++ b/examples/nonlinear_control/nonlinear_cstr_model.py
@@ -90,7 +90,7 @@ def cstr_output(x: np.ndarray, u: np.ndarray) -> np.ndarray:
 
 
 def create_nonlinear_cstr_system(
-    cstr_model_config_path: str, cstr_model_key_value: str, verbose: int
+    cstr_model_config_path: str, cstr_model_key: str, verbose: int
 ) -> NonlinearSystem:
     """
     Create a `NonlinearSystem` instance representing a nonlinear Continuous
@@ -104,7 +104,7 @@ def create_nonlinear_cstr_system(
     Args:
         cstr_model_config_path (str): The path to the YAML configuration file
             containing the CSTR system parameters.
-        cstr_model_key_value (str): The key corresponding to the CSTR system
+        cstr_model_key (str): The key corresponding to the CSTR system
             parameters to be retrieved from the configuration file.
         verbose (int): The verbosity level. If greater than 1, prints parameter
             loading details.
@@ -121,13 +121,13 @@ def create_nonlinear_cstr_system(
     """
     # Load model parameters from config file
     params = load_yaml_config_params(
-        config_file=cstr_model_config_path, key=cstr_model_key_value
+        config_file=cstr_model_config_path, key=cstr_model_key
     )
 
     if verbose > 1:
         print(
             f"    Model parameters loaded from {cstr_model_config_path} "
-            f"with key '{cstr_model_key_value}'"
+            f"with key '{cstr_model_key}'"
         )
 
     # Retrieve model parameters

--- a/examples/nonlinear_control/nonlinear_dd_mpc_example.py
+++ b/examples/nonlinear_control/nonlinear_dd_mpc_example.py
@@ -64,14 +64,14 @@ cstr_model_config_file = "nonlinear_cstr_system_params.yaml"
 cstr_model_config_path = os.path.join(
     models_config_dir, cstr_model_config_file
 )
-cstr_model_key_value = "cstr_system"
+cstr_model_key = "cstr_system"
 
 # Data-Driven MPC controller configuration file
 default_controller_config_file = "nonlinear_dd_mpc_example_params.yaml"
 default_controller_config_path = os.path.join(
     controller_config_dir, default_controller_config_file
 )
-default_controller_key_value = "nonlinear_data_driven_mpc_params"
+default_controller_key = "nonlinear_data_driven_mpc_params"
 
 # Plot parameters configuration file
 plot_params_config_file = "plot_params.yaml"
@@ -136,9 +136,9 @@ def parse_args() -> argparse.Namespace:
         "parameters.",
     )
     parser.add_argument(
-        "--controller_key_value",
+        "--controller_key",
         type=str,
-        default=default_controller_key_value,
+        default=default_controller_key,
         help="The key to access the Data-Driven MPC "
         "controller parameters in the configuration file.",
     )
@@ -236,7 +236,7 @@ def main() -> None:
 
     # Data-Driven MPC controller parameters
     controller_config_path = args.controller_config_path
-    controller_key_value = args.controller_key_value
+    controller_key = args.controller_key
 
     # Data-Driven MPC controller arguments
     n_mpc_step = args.n_mpc_step
@@ -266,7 +266,7 @@ def main() -> None:
 
     system_model = create_nonlinear_cstr_system(
         cstr_model_config_path=cstr_model_config_path,
-        cstr_model_key_value=cstr_model_key_value,
+        cstr_model_key=cstr_model_key,
         verbose=verbose,
     )
 
@@ -285,7 +285,7 @@ def main() -> None:
     p = system_model.p  # Number of outputs
     dd_mpc_config = get_nonlinear_data_driven_mpc_controller_params(
         config_file=controller_config_path,
-        controller_key_value=controller_key_value,
+        controller_key=controller_key,
         m=m,
         p=p,
         verbose=verbose,

--- a/tests/config/controllers/test_nonlinear_dd_mpc_params.yaml
+++ b/tests/config/controllers/test_nonlinear_dd_mpc_params.yaml
@@ -15,8 +15,8 @@ test_nonlinear_dd_mpc_params:
   u_range:
     - [-1.0, 1.0]
   alpha_reg_type: 0
-  lamb_alpha_s: 1e-3
-  lamb_sigma_s: 1.0e7
+  lambda_alpha_s: 1e-3
+  lambda_sigma_s: 1.0e7
   y_r: [3.0]
   ext_out_incr_in: true
   update_cost_threshold: null

--- a/tests/test_lti_dd_mpc_integration.py
+++ b/tests/test_lti_dd_mpc_integration.py
@@ -75,7 +75,7 @@ def test_lti_dd_mpc_integration(
     # Define system model
     system_model = LTISystemModel(
         config_file=TEST_LTI_MODEL_PATH,
-        model_key_value=TEST_MODEL_KEY,
+        model_key=TEST_MODEL_KEY,
         verbose=verbose,
     )
 
@@ -84,7 +84,7 @@ def test_lti_dd_mpc_integration(
     p = system_model.p  # Number of outputs
     dd_mpc_config = get_lti_data_driven_mpc_controller_params(
         config_file=TEST_LTI_DD_MPC_CONFIG_PATH,
-        controller_key_value=TEST_LTI_DD_MPC_PARAMS_KEY,
+        controller_key=TEST_LTI_DD_MPC_PARAMS_KEY,
         m=m,
         p=p,
         verbose=verbose,

--- a/tests/test_nonlinear_dd_mpc_integration.py
+++ b/tests/test_nonlinear_dd_mpc_integration.py
@@ -71,7 +71,7 @@ def test_nonlinear_dd_mpc_integration(
     p = system_model.p  # Number of outputs
     dd_mpc_config = get_nonlinear_data_driven_mpc_controller_params(
         config_file=TEST_NONLINEAR_DD_MPC_CONFIG_PATH,
-        controller_key_value=TEST_NONLINEAR_DD_MPC_PARAMS_KEY,
+        controller_key=TEST_NONLINEAR_DD_MPC_PARAMS_KEY,
         m=m,
         p=p,
         verbose=verbose,

--- a/tests/test_utilities/controller/conftest.py
+++ b/tests/test_utilities/controller/conftest.py
@@ -35,8 +35,8 @@ def test_dd_mpc_controller_yaml_config() -> dict[str, Any]:
         "y_r": [0.0],
         "n_n_mpc_step": True,
         "alpha_reg_type": 0,
-        "lamb_alpha_s": 0.01,
-        "lamb_sigma_s": 0.01,
+        "lambda_alpha_s": 0.01,
+        "lambda_sigma_s": 0.01,
         "ext_out_incr_in": False,
         "update_cost_threshold": 0.0,
     }

--- a/tests/test_utilities/controller/test_controller_params.py
+++ b/tests/test_utilities/controller/test_controller_params.py
@@ -57,7 +57,7 @@ def test_get_lti_data_driven_mpc_controller_params(
     # Load controller parameters
     params = get_lti_data_driven_mpc_controller_params(
         config_file="dummy.yaml",
-        controller_key_value="controller_key",
+        controller_key="controller_key",
         m=m,
         p=p,
     )
@@ -105,7 +105,7 @@ def test_get_nonlinear_data_driven_mpc_controller_params(
     # Load controller parameters
     params = get_nonlinear_data_driven_mpc_controller_params(
         config_file="dummy.yaml",
-        controller_key_value="controller_key",
+        controller_key="controller_key",
         m=m,
         p=p,
     )


### PR DESCRIPTION
This PR renames several variables and parameters across the codebase for consistency and simplicity.

### Key changes:
- Renamed `lamb_alpha_s` to `lambda_alpha_s` in controller configuration files, including test scripts.
- Renamed variables and parameters that contain `*key_value` to `*key`.
- Minor grammar fix in `nonlinear_data_driven_mpc_controller.py` for clarity.
