### PR TITLE
Improve verbose output in example scripts

### DIFF
--- a/direct_data_driven_mpc/utilities/controller/controller_params.py
+++ b/direct_data_driven_mpc/utilities/controller/controller_params.py
@@ -608,7 +608,8 @@ def print_parameter_loading_details(
     """
     if verbose == 1:
         print(
-            f"Loaded {controller_label} Data-Driven MPC controller parameters"
+            f"{controller_label} Data-Driven MPC controller parameters "
+            "successfully loaded"
         )
     if verbose > 1:
         print(

--- a/examples/lti_control/lti_dd_mpc_example.py
+++ b/examples/lti_control/lti_dd_mpc_example.py
@@ -251,7 +251,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--verbose",
         type=int,
-        default=2,
+        default=1,
         choices=[0, 1, 2],
         help="The verbosity level: 0 = no output, 1 = "
         "minimal output, 2 = detailed output.",
@@ -294,6 +294,10 @@ def main() -> None:
     # Verbose argument
     verbose = args.verbose
 
+    if verbose:
+        print("--- LTI Data-Driven MPC Controller Example ---")
+        print("-" * 46)
+
     # ==============================================
     # 1. Define Simulation and Controller Parameters
     # ==============================================
@@ -310,7 +314,7 @@ def main() -> None:
     # --- Define Data-Driven MPC Controller Parameters ---
     if verbose:
         print(
-            "Loading Data-Driven MPC controller parameters from "
+            "\nLoading LTI Data-Driven MPC controller parameters from "
             "configuration file"
         )
 
@@ -375,13 +379,13 @@ def main() -> None:
     n_steps = t_sim + 1  # Number of simulation steps
 
     # Create a Random Number Generator for reproducibility
-    np_random = np.random.default_rng(seed=seed)
-
     if verbose:
         if seed is None:
-            print("Random number generator initialized with a random seed")
+            print("\nInitializing random number generator with a random seed")
         else:
-            print(f"Random number generator initialized with seed: {seed}")
+            print(f"\nInitializing random number generator with seed: {seed}")
+
+    np_random = np.random.default_rng(seed=seed)
 
     # ==============================================
     # 2. Randomize Initial System State (Simulation)
@@ -407,6 +411,8 @@ def main() -> None:
     # 3. Initial Input-Output Data Generation (Simulation)
     # ====================================================
     if verbose:
+        print("\nInitial Input-Output Data Generation")
+        print("-" * 36)
         print("Generating initial input-output data")
 
     # Generate initial input-output data using a
@@ -427,7 +433,10 @@ def main() -> None:
     # 4. Data-Driven MPC Controller Instance Creation
     # ===============================================
     controller_type_str = dd_mpc_config["controller_type"].name.capitalize()
+
     if verbose:
+        print("\nLTI Data-Driven MPC Controller Evaluation")
+        print("-" * 41)
         print(f"Initializing {controller_type_str} Data-Driven MPC controller")
 
     # Create a Direct Data-Driven MPC controller
@@ -439,9 +448,7 @@ def main() -> None:
     # 5. Data-Driven MPC Control Loop
     # ===============================
     if verbose:
-        print(
-            f"Simulating {controller_type_str} Data-Driven MPC control system"
-        )
+        print("Simulating LTI Data-Driven MPC control system")
 
     # Simulate the Data-Driven MPC control system following Algorithm 1 for a
     # Data-Driven MPC Scheme, and Algorithm 2 for an n-Step Data-Driven MPC
@@ -457,6 +464,10 @@ def main() -> None:
     # =====================================================
     # 6. Plot and Animate Control System Inputs and Outputs
     # =====================================================
+    if verbose:
+        print("\nInput-Output Data Visualization")
+        print("-" * 31)
+
     N = dd_mpc_config["N"]  # Initial input-output trajectory length
 
     # Control input setpoint
@@ -476,7 +487,7 @@ def main() -> None:
     plot_params = get_plot_params(config_path=plot_params_config_path)
 
     if verbose:
-        print("Displaying control system inputs and outputs plot")
+        print("Plotting control system input and output trajectories")
 
     plot_input_output(
         u_k=u_sys,
@@ -499,8 +510,8 @@ def main() -> None:
     # Plot extended input-output data
     if verbose:
         print(
-            "Displaying control system inputs and outputs including initial "
-            "input-output measurements"
+            "Plotting control system data including initial input-output "
+            "measurements"
         )
 
     plot_input_output(
@@ -516,7 +527,7 @@ def main() -> None:
 
     # --- Animate extended input-output data ---
     if verbose:
-        print("Displaying animation from extended input-output data")
+        print("Generating animated plot of the extended input-output data")
 
     anim = plot_input_output_animation(
         u_k=U_data,
@@ -538,9 +549,9 @@ def main() -> None:
         anim_frames = math.ceil((data_length - 1) / anim_points_per_frame) + 1
 
         if verbose:
-            print("Saving extended input-output animation to file")
+            print("\nSaving extended input-output data animation")
             if verbose > 1:
-                print(f"    Saving animation to: {anim_path}")
+                print(f"    Output file: {anim_path}")
                 print(
                     f"    Animation FPS: {anim_fps}, Bitrate: {anim_bitrate} "
                     f"(video only), Data Length: {data_length}, Points per "
@@ -548,7 +559,7 @@ def main() -> None:
                     f"{anim_frames}"
                 )
 
-        # Save input-output animation as an MP4 video
+        # Save input-output animation to a file
         save_animation(
             animation=anim,
             total_frames=anim_frames,
@@ -558,9 +569,12 @@ def main() -> None:
         )
 
         if verbose:
-            print("Animation file saved successfully")
+            print(f"\nAnimation file saved successfully to {anim_path}")
 
     plt.close()  # Close figures
+
+    if verbose:
+        print("\n--- Controller example finished ---")
 
 
 if __name__ == "__main__":

--- a/examples/lti_control/paper_reproduction_utils.py
+++ b/examples/lti_control/paper_reproduction_utils.py
@@ -225,6 +225,7 @@ def create_data_driven_mpc_controllers_reproduction(
 def simulate_data_driven_mpc_control_loops_reproduction(
     system_model: LTIModel,
     data_driven_mpc_controllers: list[LTIDataDrivenMPCController],
+    controller_schemes: list[DataDrivenMPCScheme],
     n_steps: int,
     np_random: Generator,
     verbose: int,
@@ -243,8 +244,10 @@ def simulate_data_driven_mpc_control_loops_reproduction(
         system_model (LTIModel): An `LTIModel` instance representing a Linear
             Time-Invariant (LTI) system.
         data_driven_mpc_controllers (list[LTIDataDrivenMPCController]): A
-            list of `LTIDataDrivenMPCController` instances representing the
-            Data-Driven MPC controllers to be simulated.
+            list of LTI data-driven MPC controllers to be simulated.
+        controller_schemes (list[DataDrivenMPCScheme]): The corresponding MPC
+            schemes used to configure each controller in
+            `data_driven_mpc_controllers`.
         n_steps (int): The number of time steps for the simulation.
         np_random (Generator): A Numpy random number generator for generating
             random noise for the system's output.
@@ -272,7 +275,11 @@ def simulate_data_driven_mpc_control_loops_reproduction(
     n_controllers = len(data_driven_mpc_controllers)
     for i, controller in enumerate(data_driven_mpc_controllers):
         if verbose:
-            print(f"Simulating controller {i + 1}/{n_controllers}")
+            scheme_name = controller_schemes[i].name
+            print(
+                f"  [{i + 1}/{n_controllers}] Simulating controller scheme "
+                f"{scheme_name}"
+            )
 
         # Reset system internal state
         system_model.set_state(state=model_initial_state)

--- a/examples/lti_control/paper_reproduction_utils.py
+++ b/examples/lti_control/paper_reproduction_utils.py
@@ -27,7 +27,7 @@ from direct_data_driven_mpc.utilities.models.lti_model import LTIModel
 
 
 # Define Data-Driven MPC controller schemes
-class DataDrivenMPCScheme(Enum):
+class LTIDataDrivenMPCScheme(Enum):
     """
     Robust Data-Driven MPC schemes, as presented in the paper example from
     [1].
@@ -57,17 +57,17 @@ class DDMPCSchemeConfig:
 
 # Define Data-Driven MPC scheme configurations
 DD_MPC_SCHEME_CONFIG = {
-    DataDrivenMPCScheme.TEC: DDMPCSchemeConfig(
+    LTIDataDrivenMPCScheme.TEC: DDMPCSchemeConfig(
         label="TEC",
         n_mpc_step=1,
         terminal_constraints=True,
     ),
-    DataDrivenMPCScheme.TEC_N_STEP: DDMPCSchemeConfig(
+    LTIDataDrivenMPCScheme.TEC_N_STEP: DDMPCSchemeConfig(
         label="TEC, n-step",
         n_mpc_step=-1,  # -1 used as a placeholder for 'n' steps
         terminal_constraints=True,
     ),
-    DataDrivenMPCScheme.UCON: DDMPCSchemeConfig(
+    LTIDataDrivenMPCScheme.UCON: DDMPCSchemeConfig(
         label="UCON",
         n_mpc_step=1,
         terminal_constraints=False,
@@ -76,17 +76,17 @@ DD_MPC_SCHEME_CONFIG = {
 
 # Define Matplotlib line parameters for Data-Driven MPC schemes
 DD_MPC_SCHEME_LINE_PARAMS = {
-    DataDrivenMPCScheme.TEC: {
+    LTIDataDrivenMPCScheme.TEC: {
         "color": "blue",
         "linestyle": "solid",
         "linewidth": 2,
     },
-    DataDrivenMPCScheme.TEC_N_STEP: {
+    LTIDataDrivenMPCScheme.TEC_N_STEP: {
         "color": "lime",
         "linestyle": (0, (5, 5)),
         "linewidth": 2,
     },
-    DataDrivenMPCScheme.UCON: {
+    LTIDataDrivenMPCScheme.UCON: {
         "color": "black",
         "linestyle": ":",
         "linewidth": 2,
@@ -136,7 +136,7 @@ def create_data_driven_mpc_controllers_reproduction(
     controller_config: LTIDataDrivenMPCParams,
     u_d: np.ndarray,
     y_d: np.ndarray,
-    data_driven_mpc_controller_schemes: list[DataDrivenMPCScheme],
+    data_driven_mpc_controller_schemes: list[LTIDataDrivenMPCScheme],
 ) -> list[LTIDataDrivenMPCController]:
     """
     Create `LTIDataDrivenMPCController` instances for a specified list of
@@ -163,9 +163,9 @@ def create_data_driven_mpc_controllers_reproduction(
         y_d (np.ndarray): An array of shape `(N, p)` representing the system's
             output response to `u_d`. `N` is the trajectory length and `p` is
             the number of system outputs.
-        data_driven_mpc_controller_schemes (list[DataDrivenMPCScheme]): A list
-            of `DataDrivenMPCScheme` objects, which represent Robust
-            Data-Driven MPC schemes based on the paper example from [1].
+        data_driven_mpc_controller_schemes (list[LTIDataDrivenMPCScheme]): A
+            list of Robust LTI Data-Driven MPC schemes defined based on the
+            paper example from [1].
 
     Returns:
         list[LTIDataDrivenMPCController]: A list of
@@ -225,7 +225,7 @@ def create_data_driven_mpc_controllers_reproduction(
 def simulate_data_driven_mpc_control_loops_reproduction(
     system_model: LTIModel,
     data_driven_mpc_controllers: list[LTIDataDrivenMPCController],
-    controller_schemes: list[DataDrivenMPCScheme],
+    controller_schemes: list[LTIDataDrivenMPCScheme],
     n_steps: int,
     np_random: Generator,
     verbose: int,
@@ -245,8 +245,8 @@ def simulate_data_driven_mpc_control_loops_reproduction(
             Time-Invariant (LTI) system.
         data_driven_mpc_controllers (list[LTIDataDrivenMPCController]): A
             list of LTI data-driven MPC controllers to be simulated.
-        controller_schemes (list[DataDrivenMPCScheme]): The corresponding MPC
-            schemes used to configure each controller in
+        controller_schemes (list[LTIDataDrivenMPCScheme]): The corresponding
+            LTI Data-Driven MPC schemes used to configure each controller in
             `data_driven_mpc_controllers`.
         n_steps (int): The number of time steps for the simulation.
         np_random (Generator): A Numpy random number generator for generating
@@ -301,7 +301,7 @@ def simulate_data_driven_mpc_control_loops_reproduction(
 
 
 def plot_input_output_reproduction(
-    data_driven_mpc_controller_schemes: list[DataDrivenMPCScheme],
+    data_driven_mpc_controller_schemes: list[LTIDataDrivenMPCScheme],
     u_data: list[np.ndarray],
     y_data: list[np.ndarray],
     u_s: np.ndarray,
@@ -326,9 +326,8 @@ def plot_input_output_reproduction(
     for each controller scheme.
 
     Args:
-        data_driven_mpc_controller_schemes (list[DataDrivenMPCScheme]): A list
-            of `DataDrivenMPCScheme` objects representing Robust Data-Driven
-            MPC schemes.
+        data_driven_mpc_controller_schemes (list[LTIDataDrivenMPCScheme]): A
+            list of Robust LTI Data-Driven MPC schemes.
         u_data (list[np.ndarray]): A list of arrays containing control input
             data from each controller scheme simulation.
         y_data (list[np.ndarray]): A list of arrays containing system output

--- a/examples/lti_control/robust_lti_dd_mpc_reproduction.py
+++ b/examples/lti_control/robust_lti_dd_mpc_reproduction.py
@@ -145,7 +145,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--verbose",
         type=int,
-        default=2,
+        default=1,
         choices=[0, 1, 2],
         help="The verbosity level: 0 = no output, 1 = "
         "minimal output, 2 = detailed output.",
@@ -166,6 +166,10 @@ def main() -> None:
 
     # Verbose argument
     verbose = args.verbose
+
+    if verbose:
+        print("--- Robust LTI Data-Driven MPC Paper Reproduction ---")
+        print("-" * 53)
 
     # ==============================================
     # 1. Define Simulation and Controller Parameters
@@ -202,10 +206,10 @@ def main() -> None:
     n_steps = t_sim + 1  # Number of simulation steps
 
     # Create a Random Number Generator for reproducibility
-    np_random = np.random.default_rng(seed=seed)
-
     if verbose:
-        print(f"Random number generator initialized with seed: {seed}")
+        print(f"\nInitializing random number generator with seed: {seed}")
+
+    np_random = np.random.default_rng(seed=seed)
 
     # ==============================================
     # 2. Randomize Initial System State (Simulation)
@@ -231,6 +235,8 @@ def main() -> None:
     # 3. Initial Input-Output Data Generation (Simulation)
     # ====================================================
     if verbose:
+        print("\nInitial Input-Output Data Generation")
+        print("-" * 36)
         print("Generating initial input-output data")
 
     # Generate initial input-output data using a
@@ -251,11 +257,15 @@ def main() -> None:
     # 4. Data-Driven MPC Controller Instance Creation
     # ===============================================
     if verbose:
+        if verbose:
+            print("\nRobust Data-Driven MPC Controller Evaluation")
+            print("-" * 44)
+
         formatted_schemes = ", ".join(
             [scheme.name for scheme in dd_mpc_controller_schemes]
         )
         print(
-            "Initializing Robust Data-Driven MPC controllers following "
+            "Initializing Robust Data-Driven MPC controllers for "
             f"schemes: {formatted_schemes}"
         )
 
@@ -306,8 +316,8 @@ def main() -> None:
     # =============================================================
     if verbose:
         print(
-            "Simulating `n` steps using control input setpoint to "
-            "update controllers' past input-output measurements"
+            "Simulating `n` steps using the control input setpoint to "
+            "update each controller's past input-output data"
         )
 
     # Simulate `n` (the estimated system order) steps of the system using a
@@ -327,26 +337,29 @@ def main() -> None:
 
     # Update the past `n` input-output measurements of each
     # Data-Driven MPC controller (for reproduction)
-    for controller in dd_mpc_controllers:
-        controller.set_past_input_output_data(
-            u_past=U_n.reshape(-1, 1), y_past=Y_n.reshape(-1, 1)
-        )
-
     if verbose:
-        print("Controllers' past `n` input-output measurements updated")
+        print(
+            "Updating the past `n` input-output measurements for each "
+            "controller"
+        )
         if verbose > 1:
             print(
                 f"    Past input data = {U_n.shape}, Past output data = "
                 f"{Y_n.shape}"
             )
 
+    for controller in dd_mpc_controllers:
+        controller.set_past_input_output_data(
+            u_past=U_n.reshape(-1, 1), y_past=Y_n.reshape(-1, 1)
+        )
+
     # ===============================
     # 7. Data-Driven MPC Control Loop
     # ===============================
     if verbose:
         print(
-            "Starting control system simulation for each Robust "
-            "Data-Driven MPC scheme"
+            "\nStarting control system simulations for all Robust "
+            "Data-Driven MPC schemes"
         )
 
     # Simulate the Data-Driven MPC control systems following Algorithm 1 for a
@@ -363,6 +376,7 @@ def main() -> None:
             simulate_data_driven_mpc_control_loops_reproduction(
                 system_model=system_model,
                 data_driven_mpc_controllers=dd_mpc_controllers,
+                controller_schemes=dd_mpc_controller_schemes,
                 n_steps=n_steps - n,
                 np_random=np_random,
                 verbose=verbose,
@@ -385,6 +399,10 @@ def main() -> None:
     # =========================================
     # 8. Plot Control System Inputs and Outputs
     # =========================================
+    if verbose:
+        print("\nReproduction Plot Visualization")
+        print("-" * 31)
+
     # Control input setpoint
     u_s_data = np.tile(dd_mpc_config["u_s"].T, (n_steps, 1))
 
@@ -416,6 +434,9 @@ def main() -> None:
     )
 
     plt.close()  # Close figures
+
+    if verbose:
+        print("\n--- LTI Data-Driven MPC Controller Reproduction finished ---")
 
 
 if __name__ == "__main__":

--- a/examples/lti_control/robust_lti_dd_mpc_reproduction.py
+++ b/examples/lti_control/robust_lti_dd_mpc_reproduction.py
@@ -41,7 +41,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 from paper_reproduction_utils import (
-    DataDrivenMPCScheme,
+    LTIDataDrivenMPCScheme,
     create_data_driven_mpc_controllers_reproduction,
     get_equilibrium_state_from_output,
     plot_input_output_reproduction,
@@ -98,9 +98,9 @@ y_ylimits_list = [(0.4, 1.0), (0.4, 1.0)]  # Output plot Y-axis limits
 
 # Robust Data-Driven MPC controllers showcased in paper example
 dd_mpc_controller_schemes = [
-    DataDrivenMPCScheme.TEC,
-    DataDrivenMPCScheme.TEC_N_STEP,
-    DataDrivenMPCScheme.UCON,
+    LTIDataDrivenMPCScheme.TEC,
+    LTIDataDrivenMPCScheme.TEC_N_STEP,
+    LTIDataDrivenMPCScheme.UCON,
 ]
 
 

--- a/examples/nonlinear_control/nonlinear_cstr_model.py
+++ b/examples/nonlinear_control/nonlinear_cstr_model.py
@@ -159,4 +159,10 @@ def create_nonlinear_cstr_system(
         eps_max=eps_max,
     )
 
+    if verbose:
+        print(
+            "Nonlinear Continuous Stirred Tank Reactor system initialized "
+            "with loaded parameters"
+        )
+
     return cstr_system

--- a/examples/nonlinear_control/nonlinear_dd_mpc_example.py
+++ b/examples/nonlinear_control/nonlinear_dd_mpc_example.py
@@ -219,7 +219,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--verbose",
         type=int,
-        default=2,
+        default=1,
         choices=[0, 1, 2],
         help="The verbosity level: 0 = no output, 1 = "
         "minimal output, 2 = detailed output.",
@@ -257,6 +257,10 @@ def main() -> None:
     # Verbose argument
     verbose = args.verbose
 
+    if verbose:
+        print("--- Nonlinear Data-Driven MPC Controller Example ---")
+        print("-" * 52)
+
     # ==============================================
     # 1. Define Simulation and Controller Parameters
     # ==============================================
@@ -269,9 +273,6 @@ def main() -> None:
         cstr_model_key=cstr_model_key,
         verbose=verbose,
     )
-
-    if verbose:
-        print("Initialized nonlinear Continuous Stirred Tank Reactor system")
 
     # --- Define Data-Driven MPC Controller Parameters ---
     if verbose:
@@ -325,13 +326,13 @@ def main() -> None:
     n_steps = t_sim + 1  # Number of simulation steps
 
     # Create a Random Number Generator for reproducibility
-    np_random = np.random.default_rng(seed=seed)
-
     if verbose:
         if seed is None:
-            print("Random number generator initialized with a random seed")
+            print("\nInitializing random number generator with a random seed")
         else:
-            print(f"Random number generator initialized with seed: {seed}")
+            print(f"\nInitializing random number generator with seed: {seed}")
+
+    np_random = np.random.default_rng(seed=seed)
 
     # ============================================
     # 2. Set Initial System State for Reproduction
@@ -342,13 +343,12 @@ def main() -> None:
     # Set system state to x_0 for reproduction
     system_model.x = np.array(x_0)
 
-    if verbose > 1:
-        print(f"    Initial system state set to: {x_0}")
-
     # ====================================================
     # 3. Initial Input-Output Data Generation (Simulation)
     # ====================================================
     if verbose:
+        print("\nInitial Input-Output Data Generation")
+        print("-" * 36)
         print("Generating initial input-output data")
 
     # Generate initial input-output data using a
@@ -366,6 +366,8 @@ def main() -> None:
     # 4. Data-Driven MPC Controller Instance Creation
     # ===============================================
     if verbose:
+        print("\nNonlinear Data-Driven MPC Controller Evaluation")
+        print("-" * 47)
         print("Initializing Nonlinear Data-Driven MPC controller")
 
     # Create a Direct Data-Driven MPC controller
@@ -392,6 +394,10 @@ def main() -> None:
     # =====================================================
     # 6. Plot and Animate Control System Inputs and Outputs
     # =====================================================
+    if verbose:
+        print("\nInput-Output Data Visualization")
+        print("-" * 31)
+
     N = dd_mpc_config["N"]  # Initial input-output trajectory length
 
     # System output setpoint
@@ -409,7 +415,7 @@ def main() -> None:
     plot_params = get_plot_params(config_path=plot_params_config_path)
 
     if verbose:
-        print("Displaying control system inputs and outputs plot")
+        print("Plotting control system input and output trajectories")
 
     plot_input_output(
         u_k=u_sys,
@@ -430,8 +436,8 @@ def main() -> None:
     # Plot extended input-output data
     if verbose:
         print(
-            "Displaying control system inputs and outputs including "
-            "initial input-output measurements"
+            "Plotting control system data including initial input-output "
+            "measurements"
         )
 
     plot_input_output(
@@ -453,7 +459,7 @@ def main() -> None:
 
     if verbose:
         print(
-            "Displaying reproduction plot: Data-Driven MPC for Nonlinear "
+            "Displaying reproduction plot: Data-Driven MPC for nonlinear "
             "systems"
         )
 
@@ -471,7 +477,7 @@ def main() -> None:
 
     # --- Animate extended input-output data ---
     if verbose:
-        print("Displaying animation from extended input-output data")
+        print("Generating animated plot of the extended input-output data")
 
     anim = plot_input_output_animation(
         u_k=U_data,
@@ -497,9 +503,9 @@ def main() -> None:
         anim_frames = math.ceil((data_length - 1) / anim_points_per_frame) + 1
 
         if verbose:
-            print("Saving extended input-output animation to file")
+            print("\nSaving extended input-output data animation")
             if verbose > 1:
-                print(f"    Saving animation to: {anim_path}")
+                print(f"    Output file: {anim_path}")
                 print(
                     f"    Animation FPS: {anim_fps}, Bitrate: "
                     f"{anim_bitrate} (video only), Data Length: "
@@ -507,7 +513,7 @@ def main() -> None:
                     f"{anim_points_per_frame}, Total Frames: {anim_frames}"
                 )
 
-        # Save input-output animation as an MP4 video
+        # Save input-output animation to a file
         save_animation(
             animation=anim,
             total_frames=anim_frames,
@@ -517,9 +523,12 @@ def main() -> None:
         )
 
         if verbose:
-            print("Animation file saved successfully")
+            print(f"\nAnimation file saved successfully to {anim_path}")
 
     plt.close()  # Close figures
+
+    if verbose:
+        print("\n--- Controller example finished ---")
 
 
 if __name__ == "__main__":

--- a/tests/test_utilities/controller/test_controller_params.py
+++ b/tests/test_utilities/controller/test_controller_params.py
@@ -251,8 +251,8 @@ def test_print_parameter_loading_details(
         assert out == ""
     elif verbosity_level == 1:
         assert (
-            f"Loaded {controller_label} Data-Driven MPC controller "
-            "parameters\n" in out
+            f"{controller_label} Data-Driven MPC controller parameters "
+            "successfully loaded\n" in out
         )
     else:
         assert (


### PR DESCRIPTION
This PR improves the structure and readability of verbose output across example scripts and utility functions.

Additionally, it renames the `DataDrivenMPCScheme` class used for defining robust LTI data-driven MPC schemes to avoid confusion between LTI and nonlinear controller configurations.

### Key changes:
- Improved the structure of verbose output in controller example scripts.
- Made minor modifications to verbose output in utility functions.
- Set default verbosity level to 1 for all example scripts
- Renamed `DataDrivenMPCScheme` to `LTIDataDrivenMPCScheme`.
