### PR TITLE
Add Codecov upload step to CI workflow

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -127,7 +127,12 @@ jobs:
       - name: Install coverage
         run: pip install coverage
 
-      - name: Combine and show coverage report
+      - name: Generate coverage report
         run: |
           coverage combine
-          coverage report
+          coverage xml
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -52,7 +52,7 @@ jobs:
           coverage run --parallel-mode -m pytest \
             --maxfail=2 \
             --disable-warnings \
-            -m "not lti_integration and not nonlinear_integration"
+            -m "not integration"
 
       - name: Upload coverage file
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -124,8 +124,11 @@ jobs:
         with:
           name: coverage-data-nonlinear_integration
 
-      - name: Install coverage
-        run: pip install coverage
+      - name: Install Git and coverage
+        run: |
+          apt-get update \
+          && apt-get install -y --no-install-recommends git \
+          && pip install coverage
 
       - name: Generate coverage report
         run: |

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -124,10 +124,13 @@ jobs:
         with:
           name: coverage-data-nonlinear_integration
 
-      - name: Install Git and coverage
+      - name: Install dependencies
         run: |
           apt-get update \
           && apt-get install -y --no-install-recommends git \
+            git \
+            curl \
+            gpg \
           && pip install coverage
 
       - name: Generate coverage report

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run unit tests with coverage
         run: |
-          coverage run --parallel-mode -m pytest \
+          coverage run --parallel-mode --branch -m pytest \
             --maxfail=2 \
             --disable-warnings \
             -m "not integration"
@@ -90,7 +90,7 @@ jobs:
 
       - name: Run integration test with coverage - ${{ matrix.test_type }}
         run: |
-          coverage run --parallel-mode -m pytest \
+          coverage run --parallel-mode --branch -m pytest \
             --disable-warnings \
             -m "${{ matrix.test_type }}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ignore-words-list = "Ot"
 
 [tool.pytest.ini_options]
 markers =[
+  "integration: Marks all integration tests",
   "lti_integration: Integration tests for LTI controller",
   "nonlinear_integration: Integration tests for nonlinear controller"
 ]

--- a/tests/test_lti_dd_mpc_integration.py
+++ b/tests/test_lti_dd_mpc_integration.py
@@ -47,6 +47,7 @@ TEST_LTI_DD_MPC_CONFIG_PATH = os.path.join(
 TEST_LTI_DD_MPC_PARAMS_KEY = "test_lti_dd_mpc_params"
 
 
+@pytest.mark.integration
 @pytest.mark.lti_integration
 @pytest.mark.parametrize("n_n_mpc_step", [True, False])
 @pytest.mark.parametrize(

--- a/tests/test_nonlinear_dd_mpc_integration.py
+++ b/tests/test_nonlinear_dd_mpc_integration.py
@@ -42,6 +42,7 @@ TEST_NONLINEAR_DD_MPC_CONFIG_PATH = os.path.join(
 TEST_NONLINEAR_DD_MPC_PARAMS_KEY = "test_nonlinear_dd_mpc_params"
 
 
+@pytest.mark.integration
 @pytest.mark.nonlinear_integration
 @pytest.mark.parametrize("n_n_mpc_step", [True, False])
 @pytest.mark.parametrize("ext_out_incr_in", [True, False])


### PR DESCRIPTION
This PR adds a step to the CI workflow for uploading coverage reports to Codecov. This enables the use of badges for displaying the project coverage status.

### Key changes:
- Added a Codecov upload step to the `coverage_report` job in the CI workflow.
- Modified test executions in the CI workflow to enable branch coverage reports by adding the `--branch` argument.
- Simplified unit test selection by using the "not integration" pytest marker, which excludes integration tests.