### PR TITLE
Make showing comparison plots optional and add `.codecov.yml`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+---
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 0%
+        informational: false
+    patch:
+      default:
+        target: auto
+        informational: true
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default

--- a/direct_data_driven_mpc/utilities/visualization/comparison_plot.py
+++ b/direct_data_driven_mpc/utilities/visualization/comparison_plot.py
@@ -39,6 +39,7 @@ def plot_input_output_comparison(
     x_axis_labels: list[str] | None = None,
     input_y_axis_labels: list[str] | None = None,
     output_y_axis_labels: list[str] | None = None,
+    show: bool = True,
 ) -> None:
     """
     Plot multiple input-output trajectories with setpoints in a Matplotlib
@@ -136,6 +137,9 @@ def plot_input_output_comparison(
         output_y_axis_labels (list[str] | None): A list of strings specifying
             custom Y-axis labels for each output subplot. If provided, the
             label at each index will override the corresponding default label.
+        show (bool): Whether to call `plt.show()` for the figure or not. Useful
+            when adding plot elements externally before rendering the figure.
+            Defaults to `True`.
 
     Raises:
         ValueError: If input/output array shapes, or line parameter list
@@ -215,8 +219,9 @@ def plot_input_output_comparison(
             plot_setpoint_lines=plot_setpoint_lines,
         )
 
-    # Show plot
-    plt.show()
+    # Show plot if enabled
+    if show:
+        plt.show()
 
 
 def validate_comparison_plot_parameters(


### PR DESCRIPTION
This PR adds an optional `show` parameter to the `plot_input_output_comparison` function to control whether comparison plots are rendered internally (via `plt.show()`).

This is useful when customizing comparison plots externally before rendering the figure.

Additionally, this PR adds a `.codecov.yml` file to configure Codecov. It sets a minimum total coverage requirement of 80% and sets patch coverage to informative only.

### Key changes:
- Added `show` parameter to `plot_input_output_comparison` to optionally skip calling `plt.show()` in figures.
- Added `.codecov.yml` file.
