### PR TITLE
Replace "reach" with "header" in Codecov comment layout

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,5 +12,5 @@ coverage:
         informational: true
 
 comment:
-  layout: "reach, diff, files"
+  layout: "header, diff, files"
   behavior: default


### PR DESCRIPTION
This PR replaces `"reach"` with `"header"` in the layout section of PR comments in `.codecov.yml` to show coverage summaries instead of reach graphs.

Based on the latest pull request comment documentation from the [Codecov docs](https://docs.codecov.com/docs/pull-request-comments), `"reach"` appears to no longer be supported. It also hasn't been working as expected.

### Key changes:
- Replaced `"reach"` with `"header"` in the comment layout section of `.codecov.yml`.
